### PR TITLE
Feature/#24 atom 사이드바 태그버튼

### DIFF
--- a/frontend/components/atoms/SideTag/index.tsx
+++ b/frontend/components/atoms/SideTag/index.tsx
@@ -1,0 +1,33 @@
+import React, { FunctionComponent } from "react";
+import { DeleteButton, TagContainer, TagText } from "./styled";
+
+interface Props{
+    text: string;
+    tagBgColor?: string;
+    textColor?: string;
+    deleteBgColor?: string;
+    deleteHandler: Function;
+}
+
+
+const SideTag : React.VFC<Props> = ({text, tagBgColor, textColor, deleteBgColor, deleteHandler }) => {
+    return (
+        <TagContainer
+            bgColor={tagBgColor || "#94D3CC"}
+            textColor={textColor || "white"}
+            {...deleteHandler}
+        >
+            <TagText>
+                {text}
+            </TagText>
+            <DeleteButton
+                bgColor={deleteBgColor || "#fc7047"}
+                onClick={() => {deleteHandler()}}
+            >
+                🗑
+            </DeleteButton>
+        </TagContainer>
+    );
+}
+
+export default SideTag;

--- a/frontend/components/atoms/SideTag/sideTag.stories.tsx
+++ b/frontend/components/atoms/SideTag/sideTag.stories.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import SideTag from "./index";
+
+
+export default{
+    title: 'Atoms/SideTag',
+    component: SideTag
+}
+
+
+export const Default = () => {
+    return (
+        <SideTag 
+            text = "react.js"
+            deleteHadler= {() => {}}
+        />
+    );
+}
+
+export const LongTag = () => {
+    return (
+        <SideTag 
+            text = "javascript webpack"
+            deleteHadler= {() => {}}
+        />
+    );
+}
+
+export const otherColorTag = () => {
+    return (
+        <SideTag 
+            text = "javascript"
+            tagBgColor="#045D8B"
+            deleteHadler= {() => {}}
+        />
+    );
+}

--- a/frontend/components/atoms/SideTag/styled.ts
+++ b/frontend/components/atoms/SideTag/styled.ts
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+
+interface TagProps{
+    bgColor: string;
+    textColor: string;
+}
+interface DeleteButtonProps{
+    bgColor: string;
+}
+
+const TagContainer = styled.li<TagProps>`
+    display: flex;
+    justify-content: space-between;
+    width: 150px; 
+    background-color: ${props => props.bgColor};
+    border-radius: 50px;
+    color: ${props => props.textColor};
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+    margin-bottom: 15px;
+
+`;
+
+const TagText = styled.div`
+    padding: 10px 0px 10px 20px;
+`;
+
+const DeleteButton = styled.button<DeleteButtonProps>`
+    width: 30px;
+    border-radius: 0px 50px 50px 0px;
+    color: white;
+    border: none; 
+    background-color: ${props => props.bgColor};
+    cursor: pointer;
+    &:hover{
+        box-shadow: 0 5px 15px rgba(0, 0, 0, .3);
+    }
+`;
+
+
+export {TagContainer, TagText, DeleteButton};


### PR DESCRIPTION
## 이슈
#24 

## 구현한 기능
- 사이드바의 태그 버튼
- 오른족의 delete버튼을 두어서 clickHadler를 props로 넘길 수 있음


