### PR TITLE
Feature/#53 molecule 사이드바 태그검색창

### DIFF
--- a/frontend/src/components/molecules/TagSearch/TagSearch.stories.tsx
+++ b/frontend/src/components/molecules/TagSearch/TagSearch.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import TagSearch from "./index";
+
+export default {
+  title: "Molecules/TagSearch",
+  component: TagSearch,
+};
+
+export const Default = () => {
+  const tagList = ["react.js", "javascript", "react-router-dom"];
+
+  return (
+    <TagSearch 
+      tagList={tagList}
+      onSubmit={() => {}} 
+    />
+  );
+}

--- a/frontend/src/components/molecules/TagSearch/index.tsx
+++ b/frontend/src/components/molecules/TagSearch/index.tsx
@@ -1,0 +1,53 @@
+import React, { FunctionComponent, useRef, useState } from "react";
+import * as Styled from "./styled";
+
+interface Props{
+  onSubmit: VoidFunction;
+  tagList: string[]
+}
+
+const TagSearch: FunctionComponent<Props> = ({onSubmit, tagList}) => {
+  const [candidateTags, setTags] = useState<string[]>([]);
+  const inputTag = useRef<HTMLInputElement>(null);
+  const onTagClick = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const tagName = event.target.dataset.tag;
+    inputTag.current.value = tagName;
+    setTags([]);
+  }
+  const onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {value} = event.target;
+    if(value.length === 0){
+      return setTags([]);
+    }
+    const tags:string[] = tagList.filter((tag:string) => tag.startsWith(value));
+    setTags(tags);
+  }
+  const getItem = (tag: string, index:number) => {
+    return (
+      <Styled.Tag key={index} data-tag={tag} onClick={onTagClick}>
+          {tag}
+      </Styled.Tag>
+    );
+  }
+  return (
+    <Styled.Container>
+      <Styled.Input 
+        type="text"
+        placeholder="tag를 입력하세요"
+        onInput={onInput}
+        ref={inputTag}
+      />
+      <Styled.Button
+        onClick={onSubmit}
+      >추가
+      </Styled.Button>
+      {candidateTags.length !== 0 && <Styled.TagList>
+        {candidateTags.map(getItem)}  
+        </Styled.TagList>}
+    </Styled.Container>
+
+
+  );
+}
+
+export default TagSearch;

--- a/frontend/src/components/molecules/TagSearch/styled.ts
+++ b/frontend/src/components/molecules/TagSearch/styled.ts
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+
+
+
+export const Container = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+`
+
+export const Input = styled.input`
+  box-sizing: border-box;
+  height: 35px;
+  width: 130px;
+  padding: 5px;
+  border-radius: 5px 0 0 5px;
+  border: 1px solid gray;
+`;
+
+export const Button = styled.button`
+  box-sizing: border-box;
+  display: inline-block;
+  width: 50px;
+  height: 35px;
+  padding: 5px;
+  background-color: #53a4de;
+  color: white;
+  font-weight: 600;
+  border: none;
+
+`;
+
+export const TagList = styled.ul`
+  position: absolute;
+  top: 25px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 10px 0px 10px;
+  background: #FCFCFC;
+  border: 1px solid #D7D7D7;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+`;
+
+export const Tag = styled.li`
+  width: 100%;
+  cursor: pointer;
+  margin-bottom: 5px;
+  padding: 5px;
+  &:hover{
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+  }
+`;


### PR DESCRIPTION
## 이슈
#53 
## 구현한 기능
- 사이드바의 태그 검색창 컴포넌트 구현
- 태그 리스트를 props로 전달받아 사용자의 입력에 따라 해당 이름으로 시작하는 태그 드롭다운으로 나타냄
- 사용자는 아래의 후보 태그들 중에서 선택 가능