### PR TITLE
Feature/#59-Template-단일검색결과리스트UI

### DIFF
--- a/frontend/src/components/templates/SearchResults/SearchResults.stories.tsx
+++ b/frontend/src/components/templates/SearchResults/SearchResults.stories.tsx
@@ -1,0 +1,10 @@
+import SearchResults from ".";
+
+export default {
+  Component: SearchResults,
+  title: "Templates/SearchResults",
+};
+
+export const example = () => {
+  return <SearchResults />;
+};

--- a/frontend/src/components/templates/SearchResults/index.tsx
+++ b/frontend/src/components/templates/SearchResults/index.tsx
@@ -1,0 +1,45 @@
+import React, { FunctionComponent } from "react";
+import { StyledSearchResults } from "./styled";
+
+import SearchResult from "../../organisms/SearchResult";
+
+const SearchResults: FunctionComponent = () => {
+  const fetchedDataExample = [
+    {
+      title: "이것은 제목",
+      markdown: "마크다운",
+      tagDatas: [
+        { text: "react", onDelete: () => {} },
+        { text: "react", onDelete: () => {} },
+      ],
+      views: 32,
+    },
+    {
+      title: "이것은 제목2",
+      markdown: "마크다운2",
+      tagDatas: [
+        { text: "javascript", onDelete: () => {} },
+        { text: "react", onDelete: () => {} },
+      ],
+      views: 32,
+    },
+  ];
+
+  return (
+    <StyledSearchResults>
+      {fetchedDataExample.map((example, idx) => {
+        return (
+          <SearchResult
+            title={example.title}
+            markdown={example.markdown}
+            tagDatas={example.tagDatas}
+            views={example.views}
+            key={idx}
+          ></SearchResult>
+        );
+      })}
+    </StyledSearchResults>
+  );
+};
+
+export default SearchResults;

--- a/frontend/src/components/templates/SearchResults/styled.ts
+++ b/frontend/src/components/templates/SearchResults/styled.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const StyledSearchResults = styled.div`
+  display: flex;
+  flex-direction: column;
+`;


### PR DESCRIPTION
## 이슈
#59 

## 구현한 기능
1. 단일검색 결과 리스트 Template 추가
- fetch한 데이터로 map함수를 이용하여 `SearchResult`를 렌더링
- 현재는 Test Data 들어있음 Fetch로직은 추후 개발