### PR TITLE
Feature/#65-Atomic-태그버튼 UI 완성

### DIFF
--- a/frontend/src/components/atoms/Tag/Tag.stories.tsx
+++ b/frontend/src/components/atoms/Tag/Tag.stories.tsx
@@ -1,0 +1,24 @@
+import Tag from ".";
+
+export default {
+  Component: Tag,
+  title: "Atoms/Tag",
+};
+
+export const javascript = () => {
+  const onClick = () => {};
+  return (
+    <>
+      <Tag label="javscript" onClick={onClick} />
+    </>
+  );
+};
+
+export const react = () => {
+  const onClick = () => {};
+  return (
+    <>
+      <Tag label="react" onClick={onClick} />
+    </>
+  );
+};

--- a/frontend/src/components/atoms/Tag/Tag.stories.tsx
+++ b/frontend/src/components/atoms/Tag/Tag.stories.tsx
@@ -1,4 +1,4 @@
-import Tag from ".";
+import Tag from "./";
 
 export default {
   Component: Tag,

--- a/frontend/src/components/atoms/Tag/index.tsx
+++ b/frontend/src/components/atoms/Tag/index.tsx
@@ -8,7 +8,11 @@ interface Props {
 }
 
 const Tag: FunctionComponent<Props> = ({ label, onClick }) => {
-  return <StyledTag onClick={onClick}>{label}</StyledTag>;
+  return (
+    <StyledTag className="tag" onClick={onClick}>
+      {label}
+    </StyledTag>
+  );
 };
 
 export default Tag;

--- a/frontend/src/components/atoms/Tag/index.tsx
+++ b/frontend/src/components/atoms/Tag/index.tsx
@@ -1,0 +1,14 @@
+import type { NextPage } from "next";
+import { FunctionComponent, MouseEventHandler } from "react";
+import { StyledTag } from "./styled";
+
+interface Props {
+  label: string;
+  onClick: MouseEventHandler;
+}
+
+const Tag: FunctionComponent<Props> = ({ label, onClick }) => {
+  return <StyledTag onClick={onClick}>{label}</StyledTag>;
+};
+
+export default Tag;

--- a/frontend/src/components/atoms/Tag/styled.ts
+++ b/frontend/src/components/atoms/Tag/styled.ts
@@ -8,4 +8,8 @@ export const StyledTag = styled.a`
   padding: 0.4em 0.5em;
   border-width: 1px solid;
   border-radius: 3px;
+  &:hover {
+    cursor: pointer;
+    background-color: #c9742c;
+  }
 `;

--- a/frontend/src/components/atoms/Tag/styled.ts
+++ b/frontend/src/components/atoms/Tag/styled.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const StyledTag = styled.a`
+  font-size: 14px;
+  border-color: #000;
+  background-color: #f6801e;
+  color: #000;
+  padding: 0.4em 0.5em;
+  border-width: 1px solid;
+  border-radius: 3px;
+`;


### PR DESCRIPTION
## 이슈
#65 

## 구현한 기능
![javascript tag](https://user-images.githubusercontent.com/50866506/140269473-81c185d8-89f7-4ad9-9e54-c4b9eba8e78e.PNG)


- 스택오버플로우 CSS 참고
- a태그로 구현하였는데, 추후 onClick 핸들러 구현에 따라 변경예정
- 스택오버 플로우에는 a태그로 구현하고, href를 지정해주었음


### style
```css
font-size: 14px;
  border-color: #000;
  background-color: #f6801e;
  color: #000;
  padding: 0.4em 0.5em;
  border-width: 1px solid;
  border-radius: 3px;
```
### props

```js
interface Props {
  label: string;
  onClick: MouseEventHandler;
}
```
## 이슈

 Color를 변수로 지정하여 관리하는 Color - palatte를 도입해야할 필요성 

