### PR TITLE
Fix/#164 Frontend 컴포넌트 코딩 컨벤션에 맞춰 리팩토링

### DIFF
--- a/frontend/src/components/atoms/Button/index.tsx
+++ b/frontend/src/components/atoms/Button/index.tsx
@@ -1,12 +1,19 @@
 import React, { FunctionComponent } from "react";
 import Image from "next/image";
+
 import * as Styled from "./styled";
 
-interface Props {
+interface eventProps {
   type: string;
   image?: string | StaticImageData;
   text: string;
-  onClick?: VoidFunction;
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+}
+interface voidProps {
+  type: string;
+  image?: string | StaticImageData;
+  text: string;
+  onClick: () => void;
 }
 
 interface StyleProps {
@@ -42,7 +49,12 @@ const types: { [key: string]: StyleProps } = {
     height: "36px",
   },
 };
-const Button: FunctionComponent<Props> = ({ type, image, text, onClick }) => {
+const Button: FunctionComponent<eventProps | voidProps> = ({
+  type,
+  image,
+  text,
+  onClick,
+}) => {
   const buttonProps: StyleProps = types[type];
 
   return (

--- a/frontend/src/components/atoms/Chart/index.tsx
+++ b/frontend/src/components/atoms/Chart/index.tsx
@@ -1,7 +1,8 @@
-import { ChartData } from "chart.js";
 import React, { FunctionComponent } from "react";
+import { ChartData } from "chart.js";
 import { Bar, Doughnut } from "react-chartjs-2";
-import { StyledChart } from "./styled";
+
+import * as Styled from "./styled";
 
 interface ChartProps {
   type: String;
@@ -11,15 +12,15 @@ interface ChartProps {
 const Chart: FunctionComponent<ChartProps> = ({ type, data }) => {
   if (type === "Doughnut")
     return (
-      <StyledChart>
+      <Styled.Chart>
         <Doughnut data={data} width={50} height={25}></Doughnut>
-      </StyledChart>
+      </Styled.Chart>
     );
   else if (type === "Bar") {
     return (
-      <StyledChart>
+      <Styled.Chart>
         <Bar data={data} width={50} height={25}></Bar>
-      </StyledChart>
+      </Styled.Chart>
     );
   }
   return <></>;

--- a/frontend/src/components/atoms/Chart/styled.ts
+++ b/frontend/src/components/atoms/Chart/styled.ts
@@ -1,5 +1,3 @@
 import styled from "styled-components";
 
-const StyledChart = styled.div``;
-
-export { StyledChart };
+export const Chart = styled.div``;

--- a/frontend/src/components/atoms/ContentText/index.tsx
+++ b/frontend/src/components/atoms/ContentText/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
-import { StyledText } from "./styled";
+
+import * as Styled from "./styled";
 
 interface Props {
   type: string;
@@ -16,7 +17,7 @@ const types: { [key: string]: StyleProps } = {
 
 const contentText: FunctionComponent<Props> = ({ type, text }) => {
   const styleProps = types[type];
-  return <StyledText {...styleProps}>{text}</StyledText>;
+  return <Styled.Text {...styleProps}>{text}</Styled.Text>;
 };
 
 export default contentText;

--- a/frontend/src/components/atoms/ContentText/styled.ts
+++ b/frontend/src/components/atoms/ContentText/styled.ts
@@ -4,6 +4,6 @@ interface textStyleProps {
   color: string;
 }
 
-export const StyledText = styled.p<textStyleProps>`
+export const Text = styled.p<textStyleProps>`
   color: ${(props) => props.color};
 `;

--- a/frontend/src/components/atoms/HeaderText/index.tsx
+++ b/frontend/src/components/atoms/HeaderText/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
-import { StyledText } from "./styled";
+
+import * as Styled from "./styled";
 
 interface Props {
   type: string;
@@ -16,7 +17,7 @@ const types: { [key: string]: StyleProps } = {
 
 const headerText: FunctionComponent<Props> = ({ type, text }) => {
   const styleProps = types[type];
-  return <StyledText {...styleProps}>{text}</StyledText>;
+  return <Styled.Text {...styleProps}>{text}</Styled.Text>;
 };
 
 export default headerText;

--- a/frontend/src/components/atoms/HeaderText/styled.ts
+++ b/frontend/src/components/atoms/HeaderText/styled.ts
@@ -4,6 +4,6 @@ interface textStyleProps {
   color: string;
 }
 
-export const StyledText = styled.h1<textStyleProps>`
+export const Text = styled.h1<textStyleProps>`
   color: ${(props) => props.color};
 `;

--- a/frontend/src/components/atoms/IconWithNumber/index.tsx
+++ b/frontend/src/components/atoms/IconWithNumber/index.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from "react";
 import Image from "next/image";
-import { StyledIconWithNumber } from "./styled";
+
+import * as Styled from "./styled";
 import viewImg from "./views.png";
 import commentImg from "./comments.png";
 
@@ -28,10 +29,10 @@ const types: { [key: string]: StyleProps } = {
 const IconWithNumber: FunctionComponent<Props> = ({ type, value }) => {
   const styleProps = types[type];
   return (
-    <StyledIconWithNumber>
+    <Styled.IconWithNumber>
       <Image {...styleProps} />
       {value}
-    </StyledIconWithNumber>
+    </Styled.IconWithNumber>
   );
 };
 

--- a/frontend/src/components/atoms/IconWithNumber/styled.ts
+++ b/frontend/src/components/atoms/IconWithNumber/styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const StyledIconWithNumber = styled.span`
+export const IconWithNumber = styled.span`
   img {
     margin-right: 10px;
   }

--- a/frontend/src/components/atoms/Indicator/index.tsx
+++ b/frontend/src/components/atoms/Indicator/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
 interface StyleProps {
   title: string;

--- a/frontend/src/components/atoms/Input/index.tsx
+++ b/frontend/src/components/atoms/Input/index.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent, forwardRef } from "react";
+import React, { forwardRef } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/atoms/Logo/index.tsx
+++ b/frontend/src/components/atoms/Logo/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
 import Image from "next/image";
+
 import LogoImg from "./logo.png";
 import ShortLogoImg from "./shortLogo.png";
 interface Props {

--- a/frontend/src/components/atoms/MDEditor/index.tsx
+++ b/frontend/src/components/atoms/MDEditor/index.tsx
@@ -2,16 +2,17 @@ import React, { FunctionComponent } from "react";
 import "prismjs/themes/prism.css";
 import Prism from "prismjs";
 import "@toast-ui/editor/dist/toastui-editor.css";
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight";
 import { EditorProps } from "@toast-ui/react-editor";
 import dynamic from "next/dynamic";
 const Editor = dynamic<EditorProps>(
   () => import("@toast-ui/react-editor").then((m) => m.Editor),
   { ssr: false }
 );
-// const codeSyntaxHighlight = dynamic(
-//   () => import("@toast-ui/editor-plugin-code-syntax-highlight"),
-//   { ssr: false }
-// );
+const codeSyntaxHighlight = dynamic(
+  () => import("@toast-ui/editor-plugin-code-syntax-highlight").then((m) => m),
+  { ssr: false }
+);
 // const colorSyntax = dynamic(
 //   () => import("@toast-ui/editor-plugin-color-syntax").then((m) => m.default),
 //   { ssr: false }
@@ -30,6 +31,7 @@ const MDEditor: FunctionComponent<Props> = ({ editorRef }) => {
       initialEditType="markdown"
       useCommandShortcut={true}
       // plugins={[colorSyntax, [codeSyntaxHighlight, { highlighter: Prism }]]}
+      plugins={[codeSyntaxHighlight, { highlighter: Prism }]}
     />
   );
 };

--- a/frontend/src/components/atoms/SearchInput/index.tsx
+++ b/frontend/src/components/atoms/SearchInput/index.tsx
@@ -1,12 +1,13 @@
 import React, { FunctionComponent } from "react";
-import { StyledSearchInput } from "./styled";
+
+import * as Styled from "./styled";
 
 interface Props {
   placeholder: string;
 }
 
 const SearchInput: FunctionComponent<Props> = ({ placeholder }) => {
-  return <StyledSearchInput placeholder={placeholder} />;
+  return <Styled.SearchInput placeholder={placeholder} />;
 };
 
 export default SearchInput;

--- a/frontend/src/components/atoms/SearchInput/styled.ts
+++ b/frontend/src/components/atoms/SearchInput/styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const StyledSearchInput = styled.input`
+export const SearchInput = styled.input`
   width: 100%;
   border: none;
   border-bottom: 2px solid #f48024;
@@ -9,5 +9,3 @@ const StyledSearchInput = styled.input`
   }
   margin-right: 10px;
 `;
-
-export { StyledSearchInput };

--- a/frontend/src/components/atoms/SideTag/index.tsx
+++ b/frontend/src/components/atoms/SideTag/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/atoms/Switch/index.tsx
+++ b/frontend/src/components/atoms/Switch/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/atoms/Tag/index.tsx
+++ b/frontend/src/components/atoms/Tag/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, MouseEventHandler } from "react";
-import { StyledTag } from "./styled";
+
+import * as Styled from "./styled";
 
 interface Props {
   type: string;
@@ -38,9 +39,9 @@ const types: { [key: string]: StyleProps } = {
 const Tag: FunctionComponent<Props> = ({ type, name, onClick }) => {
   const styleProps = types[type];
   return (
-    <StyledTag {...styleProps} className="tag" onClick={onClick}>
+    <Styled.Tag {...styleProps} className="tag" onClick={onClick}>
       {name}
-    </StyledTag>
+    </Styled.Tag>
   );
 };
 

--- a/frontend/src/components/atoms/Tag/styled.ts
+++ b/frontend/src/components/atoms/Tag/styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-interface StyledTagProps {
+interface TagProps {
   fontSize: string;
   bgColor: string;
   color: string;
@@ -9,7 +9,7 @@ interface StyledTagProps {
   border: string;
 }
 
-export const StyledTag = styled.a<StyledTagProps>`
+export const Tag = styled.a<TagProps>`
   font-size: ${(props) => props.fontSize};
   background-color: ${(props) => props.bgColor};
   color: ${(props) => props.color};

--- a/frontend/src/components/atoms/Text/index.tsx
+++ b/frontend/src/components/atoms/Text/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/atoms/TitleInput/index.tsx
+++ b/frontend/src/components/atoms/TitleInput/index.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
-import { Input, Label, Span } from "./styled";
+
+import * as Styled from "./styled";
 
 interface Props {
   type: string;
@@ -10,10 +11,10 @@ interface Props {
 const TitleInput: FunctionComponent<Props> = ({ type, text, setText }) => {
   return (
     <>
-      <Input required />
-      <Label>
-        <Span>제목을 입력하세요.</Span>
-      </Label>
+      <Styled.Input required />
+      <Styled.Label>
+        <Styled.Span>제목을 입력하세요.</Styled.Span>
+      </Styled.Label>
     </>
   );
 };

--- a/frontend/src/components/atoms/TitleText/index.tsx
+++ b/frontend/src/components/atoms/TitleText/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+
 import { StyledText } from "./styled";
 
 interface Props {

--- a/frontend/src/components/atoms/index.ts
+++ b/frontend/src/components/atoms/index.ts
@@ -13,3 +13,4 @@ export { default as Logo } from "./Logo";
 export { default as Tag } from "./Tag";
 export { default as MDEditor } from "./MDEditor";
 export { default as MDViewer } from "./MDViewer";
+export { default as TitleInput } from "./TitleInput";

--- a/frontend/src/components/molecules/LoginModal/index.tsx
+++ b/frontend/src/components/molecules/LoginModal/index.tsx
@@ -1,7 +1,8 @@
 import React, { FunctionComponent } from "react";
 import { signIn } from "next-auth/client";
+
 import * as Styled from "./styled";
-import * as Atoms from "../../atoms";
+import { Button, Logo, TitleText, Text } from "@components/atoms";
 import Github from "./github.png";
 
 const LoginModal: FunctionComponent = () => {
@@ -11,16 +12,16 @@ const LoginModal: FunctionComponent = () => {
 
   return (
     <Styled.Div>
-      <Atoms.Logo type="Short" />
-      <Atoms.TitleText type={"default"} text={"로그인"} />
+      <Logo type="Short" />
+      <TitleText type={"default"} text={"로그인"} />
       <Styled.Divider />
-      <Atoms.Button
+      <Button
         type="Github"
         image={Github}
         text="GitHub 으로 로그인"
         onClick={signInGithub}
       />
-      <Atoms.Text
+      <Text
         type="Header"
         text="개발자들을 위한 실시간 질문/답변 커뮤니티 NPE"
       />

--- a/frontend/src/components/molecules/ProfileDropdown/index.tsx
+++ b/frontend/src/components/molecules/ProfileDropdown/index.tsx
@@ -1,8 +1,9 @@
 import React, { FunctionComponent } from "react";
 import Router from "next/router";
 import { signOut } from "next-auth/client";
+
 import * as Styled from "./styled";
-import Button from "../../atoms/Button";
+import { Button } from "@components/atoms";
 import userImg from "./user.png";
 import logoutImg from "./logout.png";
 

--- a/frontend/src/components/molecules/ProfileHeader/index.tsx
+++ b/frontend/src/components/molecules/ProfileHeader/index.tsx
@@ -1,12 +1,11 @@
 import React, { FunctionComponent } from "react";
-import * as Styled from "./styled";
-import Image from "../../atoms/Image";
-import Text from "../../atoms/Text";
 
+import * as Styled from "./styled";
+import { Image, Text } from "@components/atoms";
 interface Props {
   src: string;
   text: string;
-  onClick: () => void;
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 const ProfileHeader: FunctionComponent<Props> = ({ src, text, onClick }) => {

--- a/frontend/src/components/molecules/QuestionTitle/index.tsx
+++ b/frontend/src/components/molecules/QuestionTitle/index.tsx
@@ -1,24 +1,25 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
-import * as Atoms from "../../atoms";
+import { TitleText, Indicator } from "@components/atoms";
 
 interface Props {
   type: string;
   text: string;
 }
 
-const QuestionTitle: FunctionComponent<Props> = ({ text, type }) => {
+const QuestionTitle: FunctionComponent<Props> = ({ type, text }) => {
   return (
     <Styled.QuestionTitle>
       <Styled.TextContainer>
-        <Atoms.TitleText text={text} type="Default" />
+        <TitleText text={text} type="Default" />
         <Styled.QuestionDate>
           questioned on 2021년 11월 11일
         </Styled.QuestionDate>
       </Styled.TextContainer>
-      <div className="indicator__conatier">
-        <Atoms.Indicator type={type} />
-      </div>
+      <Styled.IndicatorContainer>
+        <Indicator type={type} />
+      </Styled.IndicatorContainer>
     </Styled.QuestionTitle>
   );
 };

--- a/frontend/src/components/molecules/QuestionTitle/styled.ts
+++ b/frontend/src/components/molecules/QuestionTitle/styled.ts
@@ -20,3 +20,5 @@ export const QuestionDate = styled.div`
   font-size: 14px;
   color: #586069;
 `;
+
+export const IndicatorContainer = styled.div``;

--- a/frontend/src/components/molecules/TagInput/index.tsx
+++ b/frontend/src/components/molecules/TagInput/index.tsx
@@ -1,7 +1,8 @@
-import React, { FunctionComponent, useState } from "react";
-import { TagSearch } from "..";
-import { Tag } from "../../atoms";
+import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
+import { TagSearch } from "@components/molecules";
+import { Tag } from "@components/atoms";
 
 interface Props {
   tagList: string[];

--- a/frontend/src/components/molecules/TagList/index.tsx
+++ b/frontend/src/components/molecules/TagList/index.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent, useState } from "react";
-import * as Styled from "./styled";
-import * as Atom from "../../atoms";
+import React, { FunctionComponent } from "react";
 
+import * as Styled from "./styled";
+import { Tag } from "@components/atoms";
 import { TagType } from "@src/types";
 interface Props {
   tags: TagType[];
@@ -13,7 +13,7 @@ const TagList: FunctionComponent<Props> = ({ tags }) => {
       {tags.map((tag) => {
         return (
           <Styled.Tag key={tag.id}>
-            <Atom.Tag type={"Default"} name={tag.name} onClick={() => {}} />
+            <Tag type={"Default"} name={tag.name} onClick={() => {}} />
           </Styled.Tag>
         );
       })}

--- a/frontend/src/components/molecules/TagSearch/index.tsx
+++ b/frontend/src/components/molecules/TagSearch/index.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useEffect, useRef, useState } from "react";
-import { getAllTags } from "../../../lib";
+import React, { createRef, FunctionComponent, useState } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {
@@ -9,11 +9,9 @@ interface Props {
 
 const TagSearch: FunctionComponent<Props> = ({ onSubmit, tagList }) => {
   const [candidateTags, setTags] = useState<string[]>([]);
-
-  const inputTag = useRef<HTMLInputElement>(null);
-  const onTagClick = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const tagName = event.target.dataset.tag;
-    inputTag.current.value = tagName;
+  const inputTag = createRef<HTMLInputElement>();
+  const onTagClick = (tag: string) => {
+    inputTag!.current!.value = tag;
     setTags([]);
   };
   const onInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -28,7 +26,7 @@ const TagSearch: FunctionComponent<Props> = ({ onSubmit, tagList }) => {
   };
   const getItem = (tag: string, index: number) => {
     return (
-      <Styled.Tag key={index} data-tag={tag} onClick={onTagClick}>
+      <Styled.Tag key={index} data-tag={tag} onClick={(tag) => onTagClick}>
         {tag}
       </Styled.Tag>
     );
@@ -45,8 +43,8 @@ const TagSearch: FunctionComponent<Props> = ({ onSubmit, tagList }) => {
       <Styled.Button
         type="button"
         onClick={() => {
-          onSubmit(inputTag.current.value);
-          inputTag.current.value = "";
+          onSubmit(inputTag!.current!.value);
+          inputTag!.current!.value = "";
         }}
       >
         추가

--- a/frontend/src/components/molecules/ViewsAndComment/index.tsx
+++ b/frontend/src/components/molecules/ViewsAndComment/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
-import * as Molecule from "..";
 import * as Styled from "./styled";
+import { IconWithNumber } from "@components/molecules";
 
 interface Props {
   viewCount: number;
@@ -14,12 +14,12 @@ const ViewsAndComment: FunctionComponent<Props> = ({
 }) => {
   return (
     <Styled.ViewsAndComment>
-      <li>
-        <Molecule.IconWithNumber type={"Views"} value={viewCount} />
-      </li>
-      <li>
-        <Molecule.IconWithNumber type={"Comments"} value={commentCount} />
-      </li>
+      <Styled.IconContainer>
+        <IconWithNumber type={"Views"} value={viewCount} />
+      </Styled.IconContainer>
+      <Styled.IconContainer>
+        <IconWithNumber type={"Comments"} value={commentCount} />
+      </Styled.IconContainer>
     </Styled.ViewsAndComment>
   );
 };

--- a/frontend/src/components/molecules/ViewsAndComment/styled.ts
+++ b/frontend/src/components/molecules/ViewsAndComment/styled.ts
@@ -6,3 +6,5 @@ export const ViewsAndComment = styled.div`
     margin-left: 10px;
   }
 `;
+
+export const IconContainer = styled.li``;

--- a/frontend/src/components/molecules/Vote/index.tsx
+++ b/frontend/src/components/molecules/Vote/index.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent } from "react";
+
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/molecules/index.ts
+++ b/frontend/src/components/molecules/index.ts
@@ -8,3 +8,4 @@ export { default as IconWithNumber } from "./IconWithNumber";
 export { default as ViewsAndComment } from "./ViewsAndComment";
 export { default as TagList } from "./TagList";
 export { default as Vote } from "./Vote";
+export { default as TagInput } from "./TagInput";

--- a/frontend/src/components/organisms/AnswerDetail/index.tsx
+++ b/frontend/src/components/organisms/AnswerDetail/index.tsx
@@ -1,4 +1,5 @@
-import React, { FunctionComponent, MouseEventHandler } from "react";
+import React, { FunctionComponent } from "react";
+
 import { AnswerDetailType } from "@src/types";
 import { DetailBody } from "@components/organisms";
 

--- a/frontend/src/components/organisms/DetailBody/index.tsx
+++ b/frontend/src/components/organisms/DetailBody/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from "react";
-import { TagList, ProfileSummary, Vote } from "@components/molecules";
 
-import { DetailType } from "@src/types";
 import * as Styled from "./styled";
+import { TagList, ProfileSummary, Vote } from "@components/molecules";
+import { DetailType } from "@src/types";
 
 interface Props {
   detail: DetailType;

--- a/frontend/src/components/organisms/Header/index.tsx
+++ b/frontend/src/components/organisms/Header/index.tsx
@@ -2,14 +2,18 @@ import React, {
   FunctionComponent,
   useState,
   useEffect,
-  useRef,
   createRef,
 } from "react";
 import { useSession } from "next-auth/client";
 import Router from "next/router";
+
 import * as Styled from "./styled";
-import * as Atoms from "../../atoms";
-import * as Molecules from "../../molecules";
+import { Logo, Input, Button } from "@components/atoms";
+import {
+  ProfileHeader,
+  ProfileDropdown,
+  LoginModal,
+} from "@components/molecules";
 
 interface Props {
   type: string;
@@ -37,14 +41,14 @@ const Header: FunctionComponent<Props> = ({ type, setTexts }) => {
   const [isLoginModal, setIsLoginModal] = useState(false);
   const searchText = createRef<HTMLInputElement>();
 
-  const onProfile = (event: React.MouseEvent<HTMLElement>) => {
+  const onProfile = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.stopPropagation();
     setIsDropdown((props) => !props);
   };
   const onDropdown = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
   };
-  const onLoginButton = (event: React.MouseEvent<HTMLElement>) => {
+  const onLoginButton = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.stopPropagation();
     setIsLoginModal(true);
     document.body.style.overflow = "hidden";
@@ -82,17 +86,17 @@ const Header: FunctionComponent<Props> = ({ type, setTexts }) => {
   return (
     <Styled.HeaderDiv>
       <Styled.LogoAnchor href="/">
-        <Atoms.Logo type="Default" />
+        <Logo type="Default" />
       </Styled.LogoAnchor>
 
       <Styled.SearchForm {...headerProps} onSubmit={submitSearch}>
-        <Atoms.Input text={"Search..."} size={"medium"} ref={searchText} />
+        <Input text={"Search..."} size={"medium"} ref={searchText} />
       </Styled.SearchForm>
 
       <Styled.ButtonDiv>
         {session?.user && (
           <div>
-            <Molecules.ProfileHeader
+            <ProfileHeader
               src={session.user.image!}
               text={session.user.name!}
               onClick={onProfile}
@@ -100,23 +104,22 @@ const Header: FunctionComponent<Props> = ({ type, setTexts }) => {
             {isDropdown && (
               <Styled.DropdownDiv>
                 <div onClick={onDropdown}>
-                  <Molecules.ProfileDropdown />
+                  <ProfileDropdown />
                 </div>
               </Styled.DropdownDiv>
             )}
           </div>
         )}
-
         {!session && (
-          <Atoms.Button type="Header" text="로그인" onClick={onLoginButton} />
+          <Button type="Header" text="로그인" onClick={onLoginButton} />
         )}
 
-        <Atoms.Button type={"Header"} text={"질문하기"} onClick={onPost} />
+        <Button type={"Header"} text={"질문하기"} onClick={onPost} />
       </Styled.ButtonDiv>
       {isLoginModal && (
         <Styled.ModalWrapper>
           <Styled.Modal onClick={onLoginModal}>
-            <Molecules.LoginModal />
+            <LoginModal />
           </Styled.Modal>
         </Styled.ModalWrapper>
       )}

--- a/frontend/src/components/organisms/Question/index.tsx
+++ b/frontend/src/components/organisms/Question/index.tsx
@@ -2,8 +2,12 @@ import React, { FunctionComponent, MouseEventHandler } from "react";
 import Link from "next/link";
 
 import * as Styled from "./styled";
-import * as Molecule from "../../molecules";
-import * as Organism from "../index";
+import {
+  ProfileSummary,
+  QuestionTitle,
+  TagList,
+  ViewsAndComment,
+} from "@components/molecules";
 import * as Type from "../../../types";
 
 interface Props {
@@ -26,14 +30,14 @@ const SearchResult: FunctionComponent<Props> = ({ question }) => {
   return (
     <Styled.Question>
       <Styled.LeftContainer>
-        <Molecule.ProfileSummary author={author} />
+        <ProfileSummary author={author} />
       </Styled.LeftContainer>
 
       <Styled.RightContainer>
         <Styled.HeaderContainer>
           <Link href={`question/${id}`}>
             <a>
-              <Molecule.QuestionTitle
+              <QuestionTitle
                 text={title}
                 type={realtimeShare ? "online" : "offline"}
               />
@@ -42,14 +46,11 @@ const SearchResult: FunctionComponent<Props> = ({ question }) => {
         </Styled.HeaderContainer>
         <Styled.DescriptContainer>{desc}</Styled.DescriptContainer>
         <Styled.TagContainer>
-          <Molecule.TagList tags={tags} />
+          <TagList tags={tags} />
         </Styled.TagContainer>
 
         <Styled.QusetionDetail>
-          <Molecule.ViewsAndComment
-            viewCount={viewCount}
-            commentCount={thumbupCount}
-          />
+          <ViewsAndComment viewCount={viewCount} commentCount={thumbupCount} />
         </Styled.QusetionDetail>
       </Styled.RightContainer>
     </Styled.Question>

--- a/frontend/src/components/organisms/QuestionDetail/index.tsx
+++ b/frontend/src/components/organisms/QuestionDetail/index.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from "react";
 
 import * as Styled from "./styled";
-import { QuestionDetailType } from "@src/types";
 import { DetailBody } from "@components/organisms";
-import { QuestionTitle } from "@src/components/molecules";
+import { QuestionTitle } from "@components/molecules";
+import { QuestionDetailType } from "@src/types";
 
 interface Props {
   question: QuestionDetailType;

--- a/frontend/src/components/organisms/SearchResult/index.tsx
+++ b/frontend/src/components/organisms/SearchResult/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, MouseEventHandler } from "react";
-import { StyledSearchResult } from "./styled";
 
+import * as Styled from "./styled";
 import { TitleText, Indicator, Tag, IconWithNumber } from "../../atoms";
 import { ProfileSummary } from "../../molecules";
 interface tag {
@@ -23,7 +23,7 @@ const SearchResult: FunctionComponent<Props> = ({
   comments,
 }) => {
   return (
-    <StyledSearchResult>
+    <Styled.SearchResult>
       <div className="profile-container">
         <div className="profile-container__profile">
           <ProfileSummary
@@ -62,7 +62,7 @@ const SearchResult: FunctionComponent<Props> = ({
           </div>
         </div>
       </div>
-    </StyledSearchResult>
+    </Styled.SearchResult>
   );
 };
 

--- a/frontend/src/components/organisms/SearchResult/styled.ts
+++ b/frontend/src/components/organisms/SearchResult/styled.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const StyledSearchResult = styled.div`
+export const SearchResult = styled.div`
   display: flex;
   min-width: 500px;
   .profile-container__profile {

--- a/frontend/src/components/organisms/SideBar/index.tsx
+++ b/frontend/src/components/organisms/SideBar/index.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent, useState } from "react";
-import { SideTag, Switch } from "../../atoms";
-import TitleText from "../../atoms/TitleText";
-import { TagSearch } from "../../molecules";
+
 import * as Styled from "./styled";
+import { SideTag, Switch, TitleText } from "@components/atoms";
+import { TagSearch } from "@components/molecules";
 
 interface Props {
   selectedTags: string[];
@@ -28,7 +28,7 @@ const SideBar: FunctionComponent<Props> = ({
     <Styled.Container>
       <TagSearch tagList={tagList} onSubmit={onSubmit} />
       <Styled.LiveContainer>
-        <TitleText text="실시간 답변" />
+        <TitleText type="Default" text="실시간 답변" />
         <Switch type={"SideBar"} isChecked={isLive} setIsChecked={setIsLive} />
       </Styled.LiveContainer>
       <Styled.UlTags>

--- a/frontend/src/components/templates/QuestionList/index.tsx
+++ b/frontend/src/components/templates/QuestionList/index.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from "react";
 
 import * as Styled from "./styled";
-import * as Organism from "@components/organisms";
-import { Question } from "@src/types";
+import { Question } from "@components/organisms";
+import { QuestionType } from "@src/types";
 
 interface Props {
-  questions: Question[];
+  questions: QuestionType[];
 }
 
 const SearchResults: FunctionComponent<Props> = ({ questions }) => {
@@ -13,9 +13,9 @@ const SearchResults: FunctionComponent<Props> = ({ questions }) => {
     <Styled.QuestionList>
       {questions.map((question) => {
         return (
-          <li key={question.id}>
-            <Organism.Question question={question} />
-          </li>
+          <Styled.QuestionItem key={question.id}>
+            <Question question={question} />
+          </Styled.QuestionItem>
         );
       })}
     </Styled.QuestionList>

--- a/frontend/src/components/templates/QuestionList/styled.ts
+++ b/frontend/src/components/templates/QuestionList/styled.ts
@@ -4,3 +4,5 @@ export const QuestionList = styled.ul`
   display: flex;
   flex-direction: column;
 `;
+
+export const QuestionItem = styled.li``;

--- a/frontend/src/components/templates/ResisterQuestion/index.tsx
+++ b/frontend/src/components/templates/ResisterQuestion/index.tsx
@@ -1,9 +1,15 @@
 import React, { FormEvent, FunctionComponent, useRef, useState } from "react";
-import { Button, Switch, Text, TitleText } from "../../atoms";
-import MDEditor from "../../atoms/MDEditor";
-import TitleInput from "../../atoms/TitleInput";
-import TagInput from "../../molecules/TagInput";
+
+import {
+  Button,
+  Switch,
+  TitleText,
+  MDEditor,
+  TitleInput,
+} from "@components/atoms";
+import { TagInput } from "@components/molecules";
 import * as Styled from "./styled";
+
 const ResisterQuestion: FunctionComponent = () => {
   const [title, setTitle] = useState<string>("");
   const [tagList, setTagList] = useState<string[]>([]);
@@ -32,7 +38,7 @@ const ResisterQuestion: FunctionComponent = () => {
       </Styled.LiveContainer>
       <MDEditor editorRef={editorRef} />
       <Styled.SubmitContainer>
-        <Button type="Submit" text="질문등록" />
+        <Button type="Submit" text="질문등록" onClick={() => {}} />
       </Styled.SubmitContainer>
     </Styled.Container>
   );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,7 +12,7 @@ export interface TagType {
   name: string;
 }
 
-export interface Question {
+export interface QuestionType {
   id: number;
   __typename: string;
   author: Author;


### PR DESCRIPTION
## 이슈
#164 
## 구현한 기능
# import

### 규칙

1. 외부모듈 내부모듈 구분하기위해 `한 줄 띄우기`
2. 내부모듈은 항상 `alias` 적용하기
3. `components`는 Atom - Molecule - Organisms - Template 순서대로 import하기
4. import 할 때 순서

```
// 외부모듈
   // react, next
   // 나머지 모듈
// 한줄 분리
// 내부모듈
   // components
   // lib
   // types
   // styled.ts
```

# Styled Components

### 규칙

1. class Name 사용하지 않기
2. HTML Tag **최대한** 직접 사용하지 않기

```jsx
import * as Styled from "./styled.ts"

<Styled.Div> </Styled.Div>
```

# API 변수명

### 규칙

1. `메서드` + `Data명` + `조건` 
2. ex) `getAllTags` ( 조건이 없으면 생략가능) ,`getQuestionById`

# Type 변수명

### 규칙

1. 변수명 뒤에 `Type` 붙이기
- why) 동일한Component 이름과 충돌하는 이슈 (최선인가?)

```jsx
export interface QuestionDetailType {
}
```