### PR TITLE
[FE/Feature] 프로필 페이지 Data fetch

### DIFF
--- a/backend/src/entities/UserHasTag.ts
+++ b/backend/src/entities/UserHasTag.ts
@@ -1,3 +1,4 @@
+import { Field, Int, ObjectType } from "type-graphql";
 import {
   BaseEntity,
   Column,
@@ -9,13 +10,22 @@ import {
 import { Tag } from "./Tag";
 import { User } from "./User";
 
+@ObjectType({
+  description: "유저의 태그 사용 관계 Object",
+})
 @Index("fk_user_has_tag_user1_idx", ["userId"], {})
 @Index("fk_user_has_tag_tag1_idx", ["tagId"], {})
 @Entity("user_has_tag")
 export class UserHasTag extends BaseEntity {
+  @Field(() => Int, {
+    description: "유저의 고유 ID",
+  })
   @Column("int", { primary: true, name: "user_id" })
   userId: number;
 
+  @Field(() => Int, {
+    description: "태그 ID",
+  })
   @Column("int", { primary: true, name: "tag_id" })
   tagId: number;
 
@@ -26,6 +36,9 @@ export class UserHasTag extends BaseEntity {
   @JoinColumn([{ name: "user_id", referencedColumnName: "id" }])
   user: User;
 
+  @Field(() => Tag, {
+    description: "태그 Object",
+  })
   @ManyToOne(() => Tag, (tag) => tag.userHasTags, {
     onDelete: "NO ACTION",
     onUpdate: "NO ACTION",
@@ -33,6 +46,9 @@ export class UserHasTag extends BaseEntity {
   @JoinColumn([{ name: "tag_id", referencedColumnName: "id" }])
   tag: Tag;
 
+  @Field(() => Int, {
+    description: "해당 태그 사용 횟수",
+  })
   @Column("int", { name: "count" })
   count: number;
 }

--- a/backend/src/graphql/resolvers/TagResolver.ts
+++ b/backend/src/graphql/resolvers/TagResolver.ts
@@ -1,9 +1,14 @@
 import { Arg, Int, Query, Resolver } from "type-graphql";
+import { getCustomRepository } from "typeorm";
 import { Tag } from "../../entities/Tag";
+import { UserHasTag } from "../../entities/UserHasTag";
+import UserHasTagRepository from "../../repositories/UserHasTagRepository";
 import TagService from "../services/TagService";
 
 @Resolver(Tag)
 export default class TagResolver {
+  private readonly userHasTagRepository =
+    getCustomRepository(UserHasTagRepository);
   @Query(() => Tag, { description: "태그 ID로 부터 태그 얻기", nullable: true })
   async getTagById(
     @Arg("id", () => Int, { description: "태그 ID" }) id: number
@@ -30,5 +35,17 @@ export default class TagResolver {
     const allTags = await TagService.getAllTags();
 
     return allTags;
+  }
+
+  @Query(() => [UserHasTag], { description: "유저가 사용한 태그 횟수 얻기" })
+  async getUserUsedTagCount(
+    @Arg("userId", () => Int, { description: "조회할 유저의 ID" })
+    userId: number
+  ) {
+    const data = await this.userHasTagRepository.getAllTagsUsedByUserByUserId(
+      userId
+    );
+
+    return data;
   }
 }

--- a/backend/src/repositories/AnswerRepository.ts
+++ b/backend/src/repositories/AnswerRepository.ts
@@ -2,7 +2,7 @@ import { EntityRepository, Repository } from "typeorm";
 import { PostAnswer } from "../entities/PostAnswer";
 import AnswerInput from "../graphql/inputTypes/AnswerInput";
 
-@EntityRepository()
+@EntityRepository(PostAnswer)
 export default class AnswerRepository extends Repository<PostAnswer> {
   public async findOneAnswerById(answerId: number): Promise<PostAnswer> {
     const answer = await this.findOne({ id: answerId });

--- a/backend/src/repositories/QuestionRepository.ts
+++ b/backend/src/repositories/QuestionRepository.ts
@@ -5,7 +5,7 @@ import { UserHasTag } from "../entities/UserHasTag";
 import NoSuchQuestionError from "../graphql/errors/NoSuchQuestionError";
 import QuestionInput from "../graphql/inputTypes/QuestionInput";
 
-@EntityRepository()
+@EntityRepository(PostQuestion)
 export default class QuestionRepository extends Repository<PostQuestion> {
   private readonly questionHasTagRepository = getRepository(PostQuestionHasTag);
   private readonly userHasTagRepository = getRepository(UserHasTag);

--- a/backend/src/repositories/TagRepository.ts
+++ b/backend/src/repositories/TagRepository.ts
@@ -2,7 +2,7 @@ import { EntityRepository, getRepository, Repository } from "typeorm";
 import { PostQuestionHasTag } from "../entities/PostQuestionHasTag";
 import { Tag } from "../entities/Tag";
 
-@EntityRepository()
+@EntityRepository(Tag)
 export default class TagRepository extends Repository<Tag> {
   private readonly questionHasTagRepository = getRepository(PostQuestionHasTag);
   public async getAllTags(): Promise<Tag[]> {

--- a/backend/src/repositories/UserHasTagRepository.ts
+++ b/backend/src/repositories/UserHasTagRepository.ts
@@ -1,0 +1,21 @@
+import { EntityRepository, getRepository, MoreThan, Repository } from "typeorm";
+import { Tag } from "../entities/Tag";
+import { User } from "../entities/User";
+import { UserHasTag } from "../entities/UserHasTag";
+
+@EntityRepository(UserHasTag)
+export default class UserHasTagRepository extends Repository<UserHasTag> {
+  private readonly userRepository = getRepository(User);
+  private readonly tagRepository = getRepository(Tag);
+
+  public async getAllTagsUsedByUserByUserId(
+    userId: number
+  ): Promise<UserHasTag[]> {
+    const data = await this.find({
+      where: { userId, count: MoreThan(0) },
+      relations: ["tag"],
+    });
+
+    return data;
+  }
+}

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -1,7 +1,7 @@
 import { EntityRepository, Repository } from "typeorm";
 import { User } from "../entities/User";
 
-@EntityRepository()
+@EntityRepository(User)
 export default class UserRepository extends Repository<User> {
   public async findOneUserById(id: number): Promise<User> {
     const user = await this.findOne({ id });

--- a/frontend/src/components/molecules/ProfileAnswer/index.tsx
+++ b/frontend/src/components/molecules/ProfileAnswer/index.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent } from "react";
+
+import { ContentText, TitleText } from "@src/components/atoms";
+import { AnswerType } from "@src/types";
+import * as Styled from "./styled";
+
+interface Props {
+  postAnswer: AnswerType;
+}
+
+const ProfileAnswer: FunctionComponent<Props> = ({ postAnswer }) => {
+  return (
+    <Styled.ProfileAnswer>
+      <TitleText type={"Default"} text={postAnswer.desc} />
+      <ContentText
+        type={"Default"}
+        text={`좋아요 ${postAnswer.thumbupCount}개 · ${
+          postAnswer.state === 1 ? "채택됨" : "채택되지 않음"
+        }`}
+      />
+    </Styled.ProfileAnswer>
+  );
+};
+
+export default ProfileAnswer;

--- a/frontend/src/components/molecules/ProfileAnswer/styled.ts
+++ b/frontend/src/components/molecules/ProfileAnswer/styled.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const ProfileAnswer = styled.div`
+  width: 600px;
+  border-top: 1px solid black;
+  margin: 0px;
+  margin-top: 16px;
+  padding: 0px 10px;
+`;

--- a/frontend/src/components/molecules/ProfileSummary/index.tsx
+++ b/frontend/src/components/molecules/ProfileSummary/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const ProfileSummary: FunctionComponent<Props> = ({ author }) => {
   return (
-    <Styled.Anchor>
+    <Styled.Anchor href={`profile/${author.id}`}>
       <Styled.ImageDiv>
         <Image
           type="Large"

--- a/frontend/src/components/organisms/ProfileAnswerSummary/index.tsx
+++ b/frontend/src/components/organisms/ProfileAnswerSummary/index.tsx
@@ -1,0 +1,26 @@
+import { TitleText } from "@src/components/atoms";
+import ProfileAnswer from "@src/components/molecules/ProfileAnswer";
+import { AnswerType } from "@src/types";
+import React, { FunctionComponent } from "react";
+
+import * as Styled from "./styled";
+
+interface Props {
+  postAnswers: AnswerType[];
+}
+
+const ProfileAnswerSummary: FunctionComponent<Props> = ({ postAnswers }) => {
+  return (
+    <Styled.ProfileAnswerSummary>
+      <TitleText type={"Default"} text={`작성한 답변(${postAnswers.length})`} />
+      {postAnswers.map((postAnswer) => (
+        <ProfileAnswer
+          postAnswer={postAnswer}
+          key={postAnswer.id}
+        ></ProfileAnswer>
+      ))}
+    </Styled.ProfileAnswerSummary>
+  );
+};
+
+export default ProfileAnswerSummary;

--- a/frontend/src/components/organisms/ProfileAnswerSummary/index.tsx
+++ b/frontend/src/components/organisms/ProfileAnswerSummary/index.tsx
@@ -1,8 +1,8 @@
+import React, { FunctionComponent } from "react";
+
 import { TitleText } from "@src/components/atoms";
 import ProfileAnswer from "@src/components/molecules/ProfileAnswer";
 import { AnswerType } from "@src/types";
-import React, { FunctionComponent } from "react";
-
 import * as Styled from "./styled";
 
 interface Props {

--- a/frontend/src/components/organisms/ProfileAnswerSummary/styled.ts
+++ b/frontend/src/components/organisms/ProfileAnswerSummary/styled.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const ProfileAnswerSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ul {
+    padding-inline-start: 0px;
+  }
+`;

--- a/frontend/src/components/organisms/ProfileQuestionSummary/index.tsx
+++ b/frontend/src/components/organisms/ProfileQuestionSummary/index.tsx
@@ -1,0 +1,26 @@
+import React, { FunctionComponent } from "react";
+
+import { TitleText } from "@src/components/atoms";
+import { QuestionType } from "@src/types";
+import { QuestionList } from "@src/components/templates";
+import * as Styled from "./styled";
+
+interface Props {
+  postQuestions: QuestionType[];
+}
+
+const ProfileQuestionSummary: FunctionComponent<Props> = ({
+  postQuestions,
+}) => {
+  return (
+    <Styled.ProfileQuestionSummary>
+      <TitleText
+        type={"Default"}
+        text={`작성한 질문(${postQuestions.length})`}
+      />
+      <QuestionList questions={postQuestions} showProfile={false} />
+    </Styled.ProfileQuestionSummary>
+  );
+};
+
+export default ProfileQuestionSummary;

--- a/frontend/src/components/organisms/ProfileQuestionSummary/styled.ts
+++ b/frontend/src/components/organisms/ProfileQuestionSummary/styled.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const ProfileQuestionSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ul {
+    padding-inline-start: 0px;
+  }
+`;

--- a/frontend/src/components/organisms/Question/index.tsx
+++ b/frontend/src/components/organisms/Question/index.tsx
@@ -12,9 +12,13 @@ import { QuestionType } from "@src/types";
 
 interface Props {
   question: QuestionType;
+  showProfile?: boolean;
 }
 
-const SearchResult: FunctionComponent<Props> = ({ question }) => {
+const SearchResult: FunctionComponent<Props> = ({
+  question,
+  showProfile = true,
+}) => {
   const onClick: MouseEventHandler = () => {};
 
   const {
@@ -29,9 +33,13 @@ const SearchResult: FunctionComponent<Props> = ({ question }) => {
   } = question;
   return (
     <Styled.Question>
-      <Styled.LeftContainer>
-        <ProfileSummary author={author} />
-      </Styled.LeftContainer>
+      {showProfile ? (
+        <Styled.LeftContainer>
+          <ProfileSummary author={author} />
+        </Styled.LeftContainer>
+      ) : (
+        ""
+      )}
 
       <Styled.RightContainer>
         <Styled.HeaderContainer>

--- a/frontend/src/components/templates/QuestionList/index.tsx
+++ b/frontend/src/components/templates/QuestionList/index.tsx
@@ -6,15 +6,19 @@ import { QuestionType } from "@src/types";
 
 interface Props {
   questions: QuestionType[];
+  showProfile?: boolean;
 }
 
-const SearchResults: FunctionComponent<Props> = ({ questions }) => {
+const SearchResults: FunctionComponent<Props> = ({
+  questions,
+  showProfile = true,
+}) => {
   return (
     <Styled.QuestionList>
       {questions.map((question) => {
         return (
           <Styled.QuestionItem key={question.id}>
-            <Question question={question} />
+            <Question question={question} showProfile={showProfile} />
           </Styled.QuestionItem>
         );
       })}

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -110,7 +110,7 @@ export const getUserInfo = async (userId: number) => {
   return { loading, error, data };
 };
 
-export const getUserChartData = async (userId: number) => {
+export const getUserProfileData = async (userId: number) => {
   const { loading, error, data } = await client.query({
     query: gql`
       query {

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -141,6 +141,15 @@ export const getUserProfileData = async (userId: number) => {
             thumbupCount
           }
         }
+        getUserUsedTagCount(userId: ${userId}) {
+          userId
+          tagId
+          tag {
+            id
+            name
+          }
+          count
+        }
       }
     `,
   });

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -17,6 +17,7 @@ import { AnswerType, QuestionType } from "@src/types";
 import ProfileAnswerSummary from "@src/components/organisms/ProfileAnswerSummary";
 import ProfileAnswer from "@src/components/molecules/ProfileAnswer";
 import ProfileQuestionSummary from "@src/components/organisms/ProfileQuestionSummary";
+import { ChartData } from "chart.js";
 
 interface Props {
   userProfileData: {
@@ -25,9 +26,13 @@ interface Props {
     postQuestions: QuestionType[];
     postAnswers: AnswerType[];
   };
+  userTagCountData: ChartData<"doughnut"> & ChartData<"bar">;
 }
 
-const ProfilePage: NextPage<Props> = ({ userProfileData }) => {
+const ProfilePage: NextPage<Props> = ({
+  userProfileData,
+  userTagCountData,
+}) => {
   // const [session, loading] = useSession();
 
   // if (!session || !session.user) {
@@ -55,8 +60,8 @@ const ProfilePage: NextPage<Props> = ({ userProfileData }) => {
         </ProfileDiv>
         <ChartWrapper>
           <ChartDiv>
-            <TitleText type={"Default"} text={"태그별"} />
-            <Chart type={"Doughnut"} data={chartData} />
+            <TitleText type={"Default"} text={"태그 사용 빈도"} />
+            <Chart type={"Doughnut"} data={userTagCountData} />
           </ChartDiv>
           <ChartDiv>
             <TitleText type={"Default"} text={"활동"} />
@@ -87,7 +92,39 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return {
     props: {
       userProfileData: data.findUserById,
+      userTagCountData: makeTagCountChartData(data.getUserUsedTagCount),
     },
+  };
+};
+
+const makeTagCountChartData = (
+  list: [
+    {
+      userId: number;
+      tagId: number;
+      tag: { id: number; name: string };
+      count: number;
+    }
+  ]
+): ChartData<"doughnut"> & ChartData<"bar"> => {
+  return {
+    labels: list.map((obj) => obj.tag.name),
+    datasets: [
+      {
+        label: "# of Votes",
+        data: list.map((obj) => obj.count),
+        backgroundColor: list.map((_) => {
+          const [c1, c2, c3] = [
+            Math.floor(Math.random() * 256),
+            Math.floor(Math.random() * 256),
+            Math.floor(Math.random() * 256),
+          ];
+
+          return `rgba(${c1},${c2},${c3},0.2)`;
+        }),
+        borderWidth: 1,
+      },
+    ],
   };
 };
 

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -16,6 +16,7 @@ import { getUserProfileData } from "@src/lib";
 import { AnswerType, QuestionType } from "@src/types";
 import ProfileAnswerSummary from "@src/components/organisms/ProfileAnswerSummary";
 import ProfileAnswer from "@src/components/molecules/ProfileAnswer";
+import ProfileQuestionSummary from "@src/components/organisms/ProfileQuestionSummary";
 
 interface Props {
   userProfileData: {
@@ -67,13 +68,9 @@ const ProfilePage: NextPage<Props> = ({ userProfileData }) => {
           </ChartDiv>
         </ChartWrapper>
         <SummaryWrapper>
-          <QuestionDiv>
-            <TitleText
-              type={"Default"}
-              text={`작성한 질문(${userProfileData.postQuestions.length})`}
-            />
-            <QuestionList questions={userProfileData.postQuestions} />
-          </QuestionDiv>
+          <ProfileQuestionSummary
+            postQuestions={userProfileData.postQuestions}
+          ></ProfileQuestionSummary>
           <ProfileAnswerSummary
             postAnswers={userProfileData.postAnswers}
           ></ProfileAnswerSummary>
@@ -163,15 +160,6 @@ const ChartDiv = styled.div`
 const SummaryWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-`;
-
-const QuestionDiv = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  ul {
-    padding-inline-start: 0px;
-  }
 `;
 
 export default ProfilePage;

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -12,19 +12,21 @@ import {
 } from "@components/atoms";
 import { Header } from "@components/organisms/";
 import { QuestionList } from "@components/templates";
-import { getUserChartData } from "@src/lib";
+import { getUserProfileData } from "@src/lib";
 import { AnswerType, QuestionType } from "@src/types";
+import ProfileAnswerSummary from "@src/components/organisms/ProfileAnswerSummary";
+import ProfileAnswer from "@src/components/molecules/ProfileAnswer";
 
 interface Props {
-  userChartData: {
+  userProfileData: {
     username: string;
     score: number;
     postQuestions: QuestionType[];
-    postAnswers: Partial<AnswerType>[];
+    postAnswers: AnswerType[];
   };
 }
 
-const ProfilePage: NextPage<Props> = ({ userChartData }) => {
+const ProfilePage: NextPage<Props> = ({ userProfileData }) => {
   // const [session, loading] = useSession();
 
   // if (!session || !session.user) {
@@ -33,7 +35,7 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
 
   return (
     <>
-      <Header type="Profile" />
+      <Header type="Profile" setTexts={() => ""} />
       <MainContainer>
         <HeaderText type={"Default"} text={"프로필"} />
         <TitleText type={"Default"} text={"기본 정보"} />
@@ -45,7 +47,7 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
             {/* <TitleText type={"Default"} text={session.user.name!} /> */}
             <TitleText
               type={"Default"}
-              text={`누적 스코어 : ${String(userChartData.score)}`}
+              text={`누적 스코어 : ${String(userProfileData.score)}`}
             />
             {/* <ContentText type={"Default"} text={session.user.email!} /> */}
           </TextDiv>
@@ -64,42 +66,18 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
             <Chart type={"Doughnut"} data={chartData} />
           </ChartDiv>
         </ChartWrapper>
-        <QuestionWrapper>
+        <SummaryWrapper>
           <QuestionDiv>
             <TitleText
               type={"Default"}
-              text={`작성한 질문(${userChartData.postQuestions.length})`}
+              text={`작성한 질문(${userProfileData.postQuestions.length})`}
             />
-            <QuestionList questions={userChartData.postQuestions} />
+            <QuestionList questions={userProfileData.postQuestions} />
           </QuestionDiv>
-          <QuestionDiv>
-            <TitleText
-              type={"Default"}
-              text={`작성한 답변(${userChartData.postAnswers.length})`}
-            />
-            {userChartData.postAnswers.map((postAnswer) => {
-              return (
-                <div
-                  style={{
-                    width: "600px",
-                    borderTop: "1px solid black",
-                    margin: "0px",
-                    marginTop: "16px",
-                    padding: "0px 10px",
-                  }}
-                >
-                  <TitleText type={"Default"} text={postAnswer.desc} />
-                  <ContentText
-                    type={"Default"}
-                    text={`좋아요 ${postAnswer.thumbupCount}개 · ${
-                      postAnswer.state === 1 ? "채택됨" : "채택되지 않음"
-                    }`}
-                  />
-                </div>
-              );
-            })}
-          </QuestionDiv>
-        </QuestionWrapper>
+          <ProfileAnswerSummary
+            postAnswers={userProfileData.postAnswers}
+          ></ProfileAnswerSummary>
+        </SummaryWrapper>
       </MainContainer>
     </>
   );
@@ -107,11 +85,11 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const userId = Number(context.query.userId);
-  const { data } = await getUserChartData(userId);
+  const { data } = await getUserProfileData(userId);
 
   return {
     props: {
-      userChartData: data.findUserById,
+      userProfileData: data.findUserById,
     },
   };
 };
@@ -182,7 +160,7 @@ const ChartDiv = styled.div`
   width: 25%;
 `;
 
-const QuestionWrapper = styled.div`
+const SummaryWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 `;

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -25,11 +25,11 @@ interface Props {
 }
 
 const ProfilePage: NextPage<Props> = ({ userChartData }) => {
-  const [session, loading] = useSession();
+  // const [session, loading] = useSession();
 
-  if (!session || !session.user) {
-    return <>error</>;
-  }
+  // if (!session || !session.user) {
+  //   return <>error</>;
+  // }
 
   return (
     <>
@@ -39,15 +39,15 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
         <TitleText type={"Default"} text={"기본 정보"} />
         <ProfileDiv>
           <ImageDiv>
-            <Image type={"Profile"} src={session.user.image!} />
+            {/* <Image type={"Profile"} src={session.user.image!} /> */}
           </ImageDiv>
           <TextDiv>
-            <TitleText type={"Default"} text={session.user.name!} />
+            {/* <TitleText type={"Default"} text={session.user.name!} /> */}
             <TitleText
               type={"Default"}
               text={`누적 스코어 : ${String(userChartData.score)}`}
             />
-            <ContentText type={"Default"} text={session.user.email!} />
+            {/* <ContentText type={"Default"} text={session.user.email!} /> */}
           </TextDiv>
         </ProfileDiv>
         <ChartWrapper>

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -106,9 +106,8 @@ const ProfilePage: NextPage<Props> = ({ userChartData }) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { data } = await getUserChartData(
-    1 /* 임시로 1번 유저를 넣음. 이후에 nextSession에서 userID를 가져와야함 */
-  );
+  const userId = Number(context.query.userId);
+  const { data } = await getUserChartData(userId);
 
   return {
     props: {

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -111,7 +111,6 @@ const makeTagCountChartData = (
     labels: list.map((obj) => obj.tag.name),
     datasets: [
       {
-        label: "# of Votes",
         data: list.map((obj) => obj.count),
         backgroundColor: list.map((_) => {
           const [c1, c2, c3] = [


### PR DESCRIPTION
## 이슈
Closes #175 
## 구현한 기능
- 프로필 요약 클릭시 프로필 페이지로 리다이렉트
- 백엔드 태그 사용 횟수 집계 API 작성
- 해당 API 호출하여 프로필 페이지에 도넛차트로 연결
  - 도넛 차트 색 태그 개수에 따라 랜덤 지정

![chart](https://user-images.githubusercontent.com/74395374/141780944-4d2f3f37-88e8-4d27-a55e-eb78a66060da.gif)

