### PR TITLE
[FE] Fix/#209 프로필 페이지 관련 버그 수정

### DIFF
--- a/frontend/src/components/molecules/ProfileSummary/index.tsx
+++ b/frontend/src/components/molecules/ProfileSummary/index.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react";
+import Router from "next/router";
 
 import * as Styled from "./styled";
 import { Image, Text } from "@components/atoms";
@@ -9,8 +10,12 @@ interface Props {
 }
 
 const ProfileSummary: FunctionComponent<Props> = ({ author }) => {
+  const onProfileButton = () => {
+    Router.push(`/profile/${author.id}`);
+  };
+
   return (
-    <Styled.Anchor href={`profile/${author.id}`}>
+    <Styled.Anchor onClick={onProfileButton}>
       <Styled.ImageDiv>
         <Image type="Large" src={author.profileUrl} />
       </Styled.ImageDiv>

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -122,16 +122,17 @@ export const getUserProfileData = async (userId: number) => {
         findUserById(id: ${userId}) {
           username
           score
+          profileUrl
           postQuestions {
             id
             title
             realtimeShare
-            author {
-              id
-              profileUrl
-              score
-              username
-            }
+              author {
+                id
+                profileUrl
+                score
+                username
+              }
             desc
             tags {
               name

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -11,7 +11,7 @@ import {
 } from "@components/atoms";
 import { Header } from "@components/organisms/";
 import { getUserProfileData } from "@src/lib";
-import { AnswerType, QuestionType } from "@src/types";
+import { AnswerType, AuthorType, QuestionType } from "@src/types";
 import ProfileAnswerSummary from "@src/components/organisms/ProfileAnswerSummary";
 import ProfileQuestionSummary from "@src/components/organisms/ProfileQuestionSummary";
 import { ChartData } from "chart.js";
@@ -21,6 +21,8 @@ interface Props {
     id: number;
     username: string;
     score: number;
+    profileUrl: string;
+    author: AuthorType;
     postQuestions: QuestionType[];
     postAnswers: AnswerType[];
   };
@@ -41,10 +43,7 @@ const ProfilePage: NextPage<Props> = ({
         <TitleText type={"Default"} text={"기본 정보"} />
         <ProfileDiv>
           <ImageDiv>
-            <Image
-              type={"Profile"}
-              src={`https://avatars.githubusercontent.com/u/${userProfileData.id}`}
-            />
+            <Image type={"Profile"} src={`${userProfileData.profileUrl}`} />
           </ImageDiv>
           <TextDiv>
             <TitleText type={"Default"} text={userProfileData.username} />

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -77,7 +77,16 @@ const ProfilePage: NextPage<Props> = ({
           </ChartDiv>
           <ChartDiv>
             <TitleText type={"Default"} text={"채택 비율"} />
-            <Chart type={"Doughnut"} data={answerStateChartData} />
+            {userProfileData.postAnswers.length !== 0 ? (
+              <Chart type={"Doughnut"} data={answerStateChartData} />
+            ) : (
+              <NoChartData>
+                <TitleText
+                  type="Default"
+                  text="아직 데이터가 없습니다"
+                ></TitleText>
+              </NoChartData>
+            )}
           </ChartDiv>
         </ChartWrapper>
         <SummaryWrapper>
@@ -153,7 +162,6 @@ const makeAnswerStateChartData = (
     labels: ["채택됨", "채택되지 않음"],
     datasets: [
       {
-        label: "# of Votes",
         data: [adoptedAnswerCount, notAdobptedAnswerCount],
         backgroundColor: ["rgba(54, 162, 235, 0.2)", "rgba(255, 99, 132, 0.2)"],
         borderWidth: 1,

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -57,11 +57,23 @@ const ProfilePage: NextPage<Props> = ({
         <ChartWrapper>
           <ChartDiv>
             <TitleText type={"Default"} text={"태그 사용 빈도"} />
-            <Chart type={"Doughnut"} data={userTagCountChartData} />
+            {userTagCountChartData.labels?.length !== 0 ? (
+              <Chart type={"Doughnut"} data={userTagCountChartData} />
+            ) : (
+              <NoChartData>
+                <TitleText
+                  type="Default"
+                  text="아직 데이터가 없습니다"
+                ></TitleText>
+              </NoChartData>
+            )}
           </ChartDiv>
           <ChartDiv>
             <TitleText type={"Default"} text={"활동"} />
-            <Chart type={"Bar"} data={dummyChartData} />
+            <NoChartData>
+              <TitleText type="Default" text="준비중입니다"></TitleText>
+            </NoChartData>
+            {/* <Chart type={"Bar"} data={dummyChartData} /> */}
           </ChartDiv>
           <ChartDiv>
             <TitleText type={"Default"} text={"채택 비율"} />
@@ -150,26 +162,11 @@ const makeAnswerStateChartData = (
   };
 };
 
-const dummyChartData = {
-  labels: ["React", "Javascript", "HTML"],
-  datasets: [
-    {
-      label: "# of Votes",
-      data: [12, 19, 3],
-      backgroundColor: [
-        "rgba(255, 99, 132, 0.2)",
-        "rgba(54, 162, 235, 0.2)",
-        "rgba(255, 206, 86, 0.2)",
-      ],
-      borderColor: [
-        "rgba(255, 99, 132, 1)",
-        "rgba(54, 162, 235, 1)",
-        "rgba(255, 206, 86, 1)",
-      ],
-      borderWidth: 1,
-    },
-  ],
-};
+const NoChartData = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 const MainContainer = styled.main`
   display: flex;


### PR DESCRIPTION
## 이슈
Closes #209 
## 구현한 기능
- 프로필 페이지 진입시 상대경로로 라우팅되는점 (예를 들어 question에서 프로필 클릭시 question/{id}/profile 로 이동) 개선
- 프로필 페이지 이미지 안나오는 버그 수정
- 프로필 페이지 사용한 태그 없을 시 빈 공간 대신 대체 문구 표시