### PR TITLE
Fix/#221 질문리스트 프로필 크기 고정 및 프로필 페이지 질문 리스트 UI수정

### DIFF
--- a/frontend/src/components/molecules/ProfileSummary/styled.ts
+++ b/frontend/src/components/molecules/ProfileSummary/styled.ts
@@ -3,12 +3,9 @@ import styled from "styled-components";
 export const Anchor = styled.a`
   display: flex;
   flex-direction: column;
-  // justify-content: space-between;
   align-items: center;
   border-radius: 8px;
-  padding: 5px 8px 5px 8px;
-  // width: 144px;
-  // height: 72px;
+  padding: 10px 8px 10px 8px;
 
   &:hover {
     cursor: pointer;
@@ -28,4 +25,7 @@ export const TextDiv = styled.div`
   display: flex;
   flex-direction: column;
   text-align: center;
+  & > span {
+    width: 95px;
+  }
 `;

--- a/frontend/src/components/organisms/Question/styled.ts
+++ b/frontend/src/components/organisms/Question/styled.ts
@@ -3,8 +3,6 @@ import styled from "styled-components";
 export const Question = styled.section`
   display: flex;
   width: 600px;
-  // height: 200px;
-  // border: 1px solid black;
   margin-bottom: 40px;
   h2 {
     margin: 0;

--- a/frontend/src/pages/profile/[userId].tsx
+++ b/frontend/src/pages/profile/[userId].tsx
@@ -183,11 +183,6 @@ const MainContainer = styled.main`
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
-
-  div {
-    margin-top: 10px;
-    margin-bottom: 20px;
-  }
 `;
 
 const ProfileDiv = styled.div`


### PR DESCRIPTION
## 이슈
#221 
## 구현한 기능
- 메인페이지 질문리스트에서 프로필 크기 고정
- 프로필페이지 질문리스트 margin 삭제