### PR TITLE
질문상세페이지 질문글 요약 위치 조정

### DIFF
--- a/frontend/src/components/organisms/DetailBody/styled.ts
+++ b/frontend/src/components/organisms/DetailBody/styled.ts
@@ -47,6 +47,7 @@ export const DetailBodyInfo = styled.div`
   padding: 10px;
   width: 100%;
   display: flex;
+  justify-content: space-between;
 `;
 
 export const TagListContainer = styled.div`


### PR DESCRIPTION
## 이슈
#290

## 구현한 기능
- 태그는 왼쪽, 이미지 프로필은 오른쪽 위치하도록 조정
- 태그가 엄청 길게 달릴때 아직 테스트 안해봄