### PR TITLE
메인 페이지 질문리스트 가로 너비 고정

### DIFF
--- a/frontend/src/components/templates/QuestionList/styled.ts
+++ b/frontend/src/components/templates/QuestionList/styled.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 export const QuestionList = styled.ul`
   display: flex;
   flex-direction: column;
+  width: 640px;
 `;
 
 export const QuestionItem = styled.li``;


### PR DESCRIPTION
## 이슈
#301 
## 구현한 기능
- 메인 페이지 질문 리스트 너비 고정으로 검색 결과 없을 때 사이드바 붙는 버그 해결
