### PR TITLE
새로고침시 게시씩 2개 생성되는거 수정

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -33,7 +33,7 @@ const MainPage: NextPage<Props> = ({ data, error, userRank, questionRank }) => {
 
   const [questionList, setQuestionList] = useState(data.searchQuestions);
   const [hasMore, setHasMore] = useState(true);
-  const [questionIndex, setQuestionIndex] = useState(0);
+  const [questionIndex, setQuestionIndex] = useState(5);
 
   const reset = () => {
     setTagList([]);


### PR DESCRIPTION
## 이슈

## 구현한 기능
- 무한 스크롤 끝에서 새로고침했을때 게시물이 2개씩 생성되는 버그 수정