### PR TITLE
Refactor/#330 인터페이스 의존성 제거 및 단위 테스트 일부 작성

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,7 +36,6 @@
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
     "typeorm-transactional-tests": "^1.1.5",
-    "typeorm-typedi-extensions": "^0.4.1",
     "typescript": "^4.4.4"
   },
   "dependencies": {

--- a/backend/src/repositories/Answer/AnswerRepository.ts
+++ b/backend/src/repositories/Answer/AnswerRepository.ts
@@ -1,11 +1,12 @@
-import { Repository } from "typeorm";
 import { PostAnswer } from "../../entities/PostAnswer";
 import AnswerInput from "../../dto/AnswerInput";
 
-export default interface AnswerRepository extends Repository<PostAnswer> {
+export default interface AnswerRepository {
   findById(answerId: number): Promise<PostAnswer>;
   findAllByUserId(userId: number): Promise<PostAnswer[]>;
   findAllByQuestionId(id: number): Promise<PostAnswer[]>;
+  saveOrUpdate(entity: PostAnswer): Promise<PostAnswer>;
   modify(answerId: number, answerInput: AnswerInput): Promise<PostAnswer>;
   deleteById(answerId: number): Promise<boolean>;
+  countByQuestionId(questionId: number): Promise<number>;
 }

--- a/backend/src/repositories/Answer/AnswerRepositoryImpl.ts
+++ b/backend/src/repositories/Answer/AnswerRepositoryImpl.ts
@@ -26,6 +26,10 @@ export default class AnswerRepositoryImpl
     return data;
   }
 
+  public async saveOrUpdate(entity: PostAnswer): Promise<PostAnswer> {
+    return await this.save(entity);
+  }
+
   public async modify(
     answerId: number,
     answerInput: AnswerInput
@@ -40,5 +44,11 @@ export default class AnswerRepositoryImpl
     const deleteResult = await this.delete({ id: answerId });
 
     return deleteResult.affected > 0;
+  }
+
+  public async countByQuestionId(questionId: number) {
+    return await this.count({
+      postQuestionId: questionId,
+    });
   }
 }

--- a/backend/src/repositories/AnswerThumb/AnswerThumbRepository.ts
+++ b/backend/src/repositories/AnswerThumb/AnswerThumbRepository.ts
@@ -1,7 +1,6 @@
 import { AnswerThumb } from "@src/entities/AnswerThumb";
-import { Repository } from "typeorm";
 
-export default interface AnswerThumbRepository extends Repository<AnswerThumb> {
+export default interface AnswerThumbRepository {
   deleteByAnswerId(answerId: number): Promise<void>;
   addNew(value: 1 | -1, answerId: number, userId: number): Promise<AnswerThumb>;
   exists(answerId: number, userId: number): Promise<boolean>;

--- a/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepository.ts
+++ b/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepository.ts
@@ -1,0 +1,7 @@
+import { PostQuestionHasTag } from "../../entities/PostQuestionHasTag";
+
+export default interface PostQuestionHasTagRepository {
+  saveOrUpdate(entity: PostQuestionHasTag): Promise<PostQuestionHasTag>;
+  deleteByQuestionId(questionId: number): Promise<boolean>;
+  findAllTagIdsByQuestionId(questionId: number): Promise<number[]>;
+}

--- a/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepositoryImpl.ts
+++ b/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepositoryImpl.ts
@@ -1,13 +1,27 @@
 import { EntityRepository, Repository } from "typeorm";
 import { PostQuestionHasTag } from "../../entities/PostQuestionHasTag";
-import PostQuestionHasTagRepository from "./PostQuestionHasTagRepostiory";
+import PostQuestionHasTagRepository from "./PostQuestionHasTagRepository";
 
 @EntityRepository(PostQuestionHasTag)
 export default class PostQuestionHasTagRepositoryImpl
   extends Repository<PostQuestionHasTag>
   implements PostQuestionHasTagRepository
 {
-  public async findAllTagIdsByQuestionId(questionId: number) {
+  public async saveOrUpdate(
+    entity: PostQuestionHasTag
+  ): Promise<PostQuestionHasTag> {
+    return await this.save(entity);
+  }
+
+  public async deleteByQuestionId(questionId: number) {
+    const result = await this.delete({ postQuestionId: questionId });
+
+    return result.affected === 0;
+  }
+
+  public async findAllTagIdsByQuestionId(
+    questionId: number
+  ): Promise<number[]> {
     const relationRows = await this.find({
       where: { postQuestionId: questionId },
       select: ["tagId"],

--- a/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepostiory.ts
+++ b/backend/src/repositories/PostQuestionHasTag/PostQuestionHasTagRepostiory.ts
@@ -1,7 +1,0 @@
-import { Repository } from "typeorm";
-import { PostQuestionHasTag } from "../../entities/PostQuestionHasTag";
-
-export default interface PostQuestionHasTagRepository
-  extends Repository<PostQuestionHasTag> {
-  findAllTagIdsByQuestionId(questionId: number): Promise<number[]>;
-}

--- a/backend/src/repositories/Question/QuestionRepository.ts
+++ b/backend/src/repositories/Question/QuestionRepository.ts
@@ -1,10 +1,8 @@
-import { EntityRepository, Repository } from "typeorm";
 import { PostQuestion } from "../../entities/PostQuestion";
-import NoSuchQuestionError from "../../errors/NoSuchQuestionError";
 import QuestionInput from "../../dto/QuestionInput";
-import { Service } from "typedi";
+import SearchQuestionInput from "@src/dto/SearchQuestionInput";
 
-export default interface QuestionRepository extends Repository<PostQuestion> {
+export default interface QuestionRepository {
   addNew(args: QuestionInput, userId: number): Promise<PostQuestion>;
   deleteById(questionId: number): Promise<boolean>;
   findAllByUserId(userId: number): Promise<PostQuestion[]>;
@@ -13,4 +11,14 @@ export default interface QuestionRepository extends Repository<PostQuestion> {
     questionId: number,
     fieldsToUpdate: Partial<QuestionInput>
   ): Promise<PostQuestion>;
+  saveOrUpdate(question: PostQuestion): Promise<PostQuestion>;
+  findAndOrderByThumbCountDesc(take: number): Promise<PostQuestion[]>;
+  findByArgs(
+    where: object,
+    skip: number,
+    take: number
+  ): Promise<PostQuestion[]>;
+  buildWhereBySearchQuery(
+    searchQuery: SearchQuestionInput
+  ): Promise<Record<string, unknown>>;
 }

--- a/backend/src/repositories/Question/QuestionRepositoryImpl.ts
+++ b/backend/src/repositories/Question/QuestionRepositoryImpl.ts
@@ -1,4 +1,14 @@
-import { EntityRepository, Repository } from "typeorm";
+import SearchQuestionInput from "../../dto/SearchQuestionInput";
+import { PostQuestionHasTag } from "../../entities/PostQuestionHasTag";
+import { Tag } from "../../entities/Tag";
+import {
+  createQueryBuilder,
+  EntityRepository,
+  In,
+  Like,
+  Repository,
+  SelectQueryBuilder,
+} from "typeorm";
 import QuestionInput from "../../dto/QuestionInput";
 import { PostQuestion } from "../../entities/PostQuestion";
 import NoSuchQuestionError from "../../errors/NoSuchQuestionError";
@@ -55,5 +65,78 @@ export default class QuestionRepositoryImpl
     partialQuestion.realtimeShare = fieldsToUpdate.realtimeShare ? 1 : 0;
 
     return await this.save(partialQuestion);
+  }
+
+  public async saveOrUpdate(question: PostQuestion): Promise<PostQuestion> {
+    return await this.save(question);
+  }
+
+  public async findAndOrderByThumbCountDesc(
+    take: number
+  ): Promise<PostQuestion[]> {
+    return await this.find({
+      take: 5,
+      order: { thumbupCount: "DESC" },
+    });
+  }
+
+  public async findByArgs(
+    where: object,
+    skip: number,
+    take: number
+  ): Promise<PostQuestion[]> {
+    const queryBuilder = this.createQueryBuilder()
+      .where(where)
+      .skip(skip)
+      .take(take)
+      .orderBy("id", "DESC");
+
+    return await queryBuilder.getMany();
+  }
+
+  public async buildWhereBySearchQuery(
+    searchQuery: SearchQuestionInput
+  ): Promise<Record<string, unknown>> {
+    const { tagIDs, title, desc, realtimeShare } = searchQuery;
+    const whereObj: Record<string, unknown> = {};
+
+    if (realtimeShare) whereObj.realtimeShare = realtimeShare;
+    if (title) whereObj.title = Like(`%${title}%`);
+    if (desc) whereObj.desc = Like(`%${desc}%`);
+
+    function subQueryBuilderFromTagId(
+      tagId: number,
+      qb: SelectQueryBuilder<unknown>
+    ) {
+      return qb
+        .subQuery()
+        .from(Tag, "t")
+        .select("t_q.post_question_id", "qid")
+        .where(`t.id=${tagId}`)
+        .leftJoin(PostQuestionHasTag, "t_q", "t.id=t_q.tag_id");
+    }
+
+    if (tagIDs && tagIDs.length) {
+      let tagQueryBuilder = createQueryBuilder()
+        .select("t0.qid")
+        .from((qb) => subQueryBuilderFromTagId(tagIDs[0], qb), "t0");
+
+      for (let i = 1; i < tagIDs.length; i++) {
+        tagQueryBuilder.innerJoin(
+          (qb) => subQueryBuilderFromTagId(tagIDs[i], qb),
+          // alias
+          `t${i}`,
+          // ON
+          `t0.qid=t${i}.qid`
+        );
+      }
+
+      const qidArray = (await tagQueryBuilder.getRawMany()).map(
+        (qid) => qid.qid
+      );
+      whereObj.id = In(qidArray);
+    }
+
+    return whereObj;
   }
 }

--- a/backend/src/repositories/QuestionThumb/QuestionThumbRepository.ts
+++ b/backend/src/repositories/QuestionThumb/QuestionThumbRepository.ts
@@ -1,8 +1,6 @@
 import { QuestionThumb } from "@src/entities/QuestionThumb";
-import { Repository } from "typeorm";
 
-export default interface QuestionThumbRepository
-  extends Repository<QuestionThumb> {
+export default interface QuestionThumbRepository {
   deleteByQuestionId(questionId: number): Promise<void>;
   addNew(
     value: 1 | -1,

--- a/backend/src/repositories/User/UserRepository.ts
+++ b/backend/src/repositories/User/UserRepository.ts
@@ -1,9 +1,11 @@
+import UserDto from "@src/dto/UserDto";
 import "reflect-metadata";
-import { Service } from "typedi";
-import { EntityRepository, Repository } from "typeorm";
 import { User } from "../../entities/User";
 
-export default interface UserRepository extends Repository<User> {
+export default interface UserRepository {
   findById(id: number): Promise<User>;
   findByUsername(username: string): Promise<User>;
+  addNew(user: UserDto): Promise<User>;
+  saveOrUpdate(user: User): Promise<User>;
+  findAndOrderByScoreDesc(take: number): Promise<User[]>;
 }

--- a/backend/src/repositories/User/UserRepositoryImpl.ts
+++ b/backend/src/repositories/User/UserRepositoryImpl.ts
@@ -1,3 +1,4 @@
+import UserDto from "@src/dto/UserDto";
 import { EntityRepository, Repository } from "typeorm";
 import { User } from "../../entities/User";
 import UserRepository from "./UserRepository";
@@ -17,5 +18,23 @@ export default class UserRepositoryImpl
     const user = await this.findOne({ username });
 
     return user;
+  }
+
+  public async saveOrUpdate(user: User): Promise<User> {
+    return await this.save(user);
+  }
+
+  public async addNew(userDto: UserDto): Promise<User> {
+    const newUser = new User();
+    newUser.id = userDto.id;
+    newUser.username = userDto.username;
+    newUser.profileUrl = userDto.profileUrl;
+    newUser.socialUrl = userDto.socialUrl;
+
+    return await this.save(newUser);
+  }
+
+  public async findAndOrderByScoreDesc(take: number): Promise<User[]> {
+    return await this.find({ take, order: { score: "DESC" } });
   }
 }

--- a/backend/src/repositories/UserHasTag/UserHasTagRepository.ts
+++ b/backend/src/repositories/UserHasTag/UserHasTagRepository.ts
@@ -1,7 +1,8 @@
-import { Repository } from "typeorm";
 import { UserHasTag } from "../../entities/UserHasTag";
 
-export default interface UserHasTagRepository extends Repository<UserHasTag> {
+export default interface UserHasTagRepository {
   findAllTagIdsByUserId(userId: number): Promise<UserHasTag[]>;
   findAllByUserId(userId: number): Promise<UserHasTag[]>;
+  findByUserIdAndTagId(userId: number, tagId: number): Promise<UserHasTag>;
+  saveOrUpdate(userHasTag: UserHasTag): Promise<UserHasTag>;
 }

--- a/backend/src/repositories/UserHasTag/UserHasTagRepositoryImpl.ts
+++ b/backend/src/repositories/UserHasTag/UserHasTagRepositoryImpl.ts
@@ -23,4 +23,18 @@ export default class UserHasTagRepositoryImpl
 
     return data;
   }
+
+  public async findByUserIdAndTagId(
+    userId: number,
+    tagId: number
+  ): Promise<UserHasTag> {
+    return await this.findOne({
+      userId: userId,
+      tagId: tagId,
+    });
+  }
+
+  public async saveOrUpdate(userHasTag: UserHasTag) {
+    return await this.save(userHasTag);
+  }
 }

--- a/backend/src/services/Answer/AnswerServiceImpl.ts
+++ b/backend/src/services/Answer/AnswerServiceImpl.ts
@@ -49,7 +49,7 @@ export default class AnswerServiceImpl implements AnswerService {
     author.score += 10;
     await this.userRepository.saveOrUpdate(author);
 
-    return await this.answerRepository.save(newAnswer);
+    return await this.answerRepository.saveOrUpdate(newAnswer);
   }
 
   public async findById(answerId: number): Promise<PostAnswer> {
@@ -65,7 +65,7 @@ export default class AnswerServiceImpl implements AnswerService {
     const answer = await this.answerRepository.findById(answerId);
     answer.desc = answerInput.desc;
 
-    return await this.answerRepository.save(answer);
+    return await this.answerRepository.saveOrUpdate(answer);
   }
 
   public async delete(answerId: number): Promise<boolean> {
@@ -97,9 +97,9 @@ export default class AnswerServiceImpl implements AnswerService {
       question.adopted = 1;
       answer.state = 1;
       answerAuthor.score += 50;
-      await this.answerRepository.save(answer);
+      await this.answerRepository.saveOrUpdate(answer);
       await this.userRepository.saveOrUpdate(answerAuthor);
-      await this.questionRepository.save(question);
+      await this.questionRepository.saveOrUpdate(question);
       return true;
     } else {
       return false;

--- a/backend/src/services/Answer/AnswerServiceImpl.ts
+++ b/backend/src/services/Answer/AnswerServiceImpl.ts
@@ -47,7 +47,7 @@ export default class AnswerServiceImpl implements AnswerService {
 
     const author = await this.userRepository.findById(userId);
     author.score += 10;
-    await this.userRepository.save(author);
+    await this.userRepository.saveOrUpdate(author);
 
     return await this.answerRepository.save(newAnswer);
   }
@@ -98,7 +98,7 @@ export default class AnswerServiceImpl implements AnswerService {
       answer.state = 1;
       answerAuthor.score += 50;
       await this.answerRepository.save(answer);
-      await this.userRepository.save(answerAuthor);
+      await this.userRepository.saveOrUpdate(answerAuthor);
       await this.questionRepository.save(question);
       return true;
     } else {

--- a/backend/src/services/Question/QuestionService.ts
+++ b/backend/src/services/Question/QuestionService.ts
@@ -3,7 +3,7 @@ import SearchQuestionInput from "../../dto/SearchQuestionInput";
 import { PostQuestion } from "../../entities/PostQuestion";
 
 export default interface QuestionService {
-  search(args: SearchQuestionInput): Promise<PostQuestion[]>;
+  search(searchQuery: SearchQuestionInput): Promise<PostQuestion[]>;
   findAllByUserId(userId: number): Promise<PostQuestion[]>;
   findById(id: number): Promise<PostQuestion>;
   viewById(id: number): Promise<PostQuestion>;

--- a/backend/src/services/Tag/TagServiceImpl.ts
+++ b/backend/src/services/Tag/TagServiceImpl.ts
@@ -1,8 +1,6 @@
 import { UserHasTag } from "../../entities/UserHasTag";
 import Container from "typedi";
-import { createQueryBuilder } from "typeorm";
 import { Tag } from "../../entities/Tag";
-import { User } from "../../entities/User";
 import TagRepository from "../../repositories/Tag/TagRepository";
 import TagService from "./TagService";
 import PostQuestionHasTagRepository from "@src/repositories/PostQuestionHasTag/PostQuestionHasTagRepostiory";

--- a/backend/src/services/Tag/TagServiceImpl.ts
+++ b/backend/src/services/Tag/TagServiceImpl.ts
@@ -3,7 +3,7 @@ import Container from "typedi";
 import { Tag } from "../../entities/Tag";
 import TagRepository from "../../repositories/Tag/TagRepository";
 import TagService from "./TagService";
-import PostQuestionHasTagRepository from "@src/repositories/PostQuestionHasTag/PostQuestionHasTagRepostiory";
+import PostQuestionHasTagRepository from "@src/repositories/PostQuestionHasTag/PostQuestionHasTagRepository";
 import UserHasTagRepository from "@src/repositories/UserHasTag/UserHasTagRepository";
 
 export default class TagServiceImpl implements TagService {

--- a/backend/src/services/Thumb/ThumbServiceImpl.ts
+++ b/backend/src/services/Thumb/ThumbServiceImpl.ts
@@ -32,7 +32,7 @@ export default class ThumbServiceImpl {
 
     const question = await this.questionRepository.findById(questionId);
     question.thumbupCount++;
-    await this.questionRepository.save(question);
+    await this.questionRepository.saveOrUpdate(question);
 
     return true;
   }
@@ -51,7 +51,7 @@ export default class ThumbServiceImpl {
 
     const question = await this.questionRepository.findById(questionId);
     question.thumbupCount--;
-    await this.questionRepository.save(question);
+    await this.questionRepository.saveOrUpdate(question);
 
     return true;
   }
@@ -70,7 +70,7 @@ export default class ThumbServiceImpl {
 
     const answer = await this.answerRepository.findById(answerId);
     answer.thumbupCount++;
-    await this.answerRepository.save(answer);
+    await this.answerRepository.saveOrUpdate(answer);
 
     return true;
   }
@@ -89,7 +89,7 @@ export default class ThumbServiceImpl {
 
     const answer = await this.answerRepository.findById(answerId);
     answer.thumbupCount--;
-    await this.answerRepository.save(answer);
+    await this.answerRepository.saveOrUpdate(answer);
 
     return true;
   }

--- a/backend/src/services/User/UserServiceImpl.ts
+++ b/backend/src/services/User/UserServiceImpl.ts
@@ -24,20 +24,11 @@ export default class UserServiceImpl implements UserService {
   }
 
   public async register(userDto: UserDto): Promise<User> {
-    const newUser = new User();
-    newUser.id = userDto.id;
-    newUser.username = userDto.username;
-    newUser.profileUrl = userDto.profileUrl;
-    newUser.socialUrl = userDto.socialUrl;
-
-    return await this.userRepository.save(newUser);
+    return await this.userRepository.addNew(userDto);
   }
 
   public async getRank(): Promise<User[]> {
-    const users = this.userRepository.find({
-      take: 5,
-      order: { score: "DESC" },
-    });
+    const users = this.userRepository.findAndOrderByScoreDesc(5);
 
     return users;
   }

--- a/backend/test/unit/repository/TagRepo.test.ts
+++ b/backend/test/unit/repository/TagRepo.test.ts
@@ -1,0 +1,78 @@
+import TagRepositoryImpl from "@src/repositories/Tag/TagRepositoryImpl";
+
+describe("TagRepository", () => {
+  let instance: TagRepositoryImpl;
+
+  beforeEach(() => {
+    // 인스턴스 초기화
+    instance = new TagRepositoryImpl();
+  });
+
+  it("findAll", async () => {
+    // given
+    instance.find = jest.fn();
+
+    // when
+    await instance.findAll();
+
+    // then
+    expect(instance.find).toBeCalledWith();
+    expect(instance.find).toBeCalledTimes(1);
+  });
+
+  it("findById", async () => {
+    // given
+    const TAG_ID = 1;
+
+    instance.findOne = jest.fn();
+
+    // when
+    await instance.findById(TAG_ID);
+
+    // then
+    expect(instance.findOne).toBeCalledWith({ id: TAG_ID });
+    expect(instance.findOne).toBeCalledTimes(1);
+  });
+
+  it("findByName", async () => {
+    // given
+    const TAG_NAME = "TAGTAG";
+
+    instance.findOne = jest.fn();
+
+    // when
+    await instance.findByName(TAG_NAME);
+
+    // then
+    expect(instance.findOne).toBeCalledWith({ name: TAG_NAME });
+    expect(instance.findOne).toBeCalledTimes(1);
+  });
+
+  it("findByIds 빈 배열로 호출", async () => {
+    // given
+    const IDS: number[] = [];
+
+    instance.find = jest.fn();
+
+    // when
+    const result = await instance.findByIds(IDS);
+
+    // then
+    expect(result).toStrictEqual([]);
+    expect(instance.find).not.toBeCalled();
+  });
+
+  it("findByIds", async () => {
+    // given
+    const IDS = [1, 2];
+
+    instance.find = jest.fn();
+
+    // when
+    await instance.findByIds(IDS);
+
+    // then
+    expect(instance.find).toBeCalledWith({ where: [{ id: 1 }, { id: 2 }] });
+    expect(instance.find).toBeCalledTimes(1);
+  });
+});

--- a/backend/test/unit/repository/UserRepo.test.ts
+++ b/backend/test/unit/repository/UserRepo.test.ts
@@ -1,0 +1,84 @@
+import "reflect-metadata";
+import UserDto from "@src/dto/UserDto";
+import { User } from "@src/entities/User";
+import UserRepositoryImpl from "@src/repositories/User/UserRepositoryImpl";
+import { when } from "jest-when";
+
+describe("UserRepository", () => {
+  let instance: UserRepositoryImpl;
+
+  beforeEach(() => {
+    // 인스턴스 초기화
+    instance = new UserRepositoryImpl();
+  });
+
+  it("findById", async () => {
+    // given
+    const USER_ID = 1;
+    const user = new User();
+    user.id = USER_ID;
+    user.username = "David";
+    instance.findOne = jest.fn();
+
+    // when
+    when(instance.findOne).calledWith({ id: USER_ID }).mockResolvedValue(user);
+    const resultUser = await instance.findById(USER_ID);
+
+    // then
+    expect(resultUser).toBe(user);
+  });
+
+  it("findByUsername", async () => {
+    // given
+    const USER_USERNAME = "David";
+    const user = new User();
+    user.id = 1;
+    user.username = USER_USERNAME;
+    instance.findOne = jest.fn();
+    when(instance.findOne)
+      .calledWith({ username: USER_USERNAME })
+      .mockResolvedValue(user);
+
+    // when
+    const resultUser = await instance.findByUsername(USER_USERNAME);
+
+    // then
+    expect(resultUser).toBe(user);
+  });
+
+  it("addNew", async () => {
+    // given
+    const userDto = new UserDto();
+    userDto.id = 1;
+    userDto.username = "David";
+    userDto.profileUrl = "www.naver.com";
+    userDto.socialUrl = "www.github.com";
+
+    instance.save = jest.fn().mockImplementation((user: User) => user);
+
+    // when
+    const resultUser = await instance.addNew(userDto);
+
+    // then
+    expect(resultUser.id).toBe(userDto.id);
+    expect(resultUser.username).toBe(userDto.username);
+    expect(resultUser.profileUrl).toBe(userDto.profileUrl);
+    expect(resultUser.socialUrl).toBe(userDto.socialUrl);
+  });
+
+  it("findAndOrderByScoreDesc", async () => {
+    // given
+    const TAKE = 5;
+
+    instance.find = jest.fn();
+
+    // when
+    await instance.findAndOrderByScoreDesc(TAKE);
+
+    // then
+    expect(instance.find).toBeCalledWith({
+      take: TAKE,
+      order: { score: "DESC" },
+    });
+  });
+});

--- a/backend/test/unit/repository/UserRepo.test.ts
+++ b/backend/test/unit/repository/UserRepo.test.ts
@@ -18,14 +18,15 @@ describe("UserRepository", () => {
     const user = new User();
     user.id = USER_ID;
     user.username = "David";
+
     instance.findOne = jest.fn();
 
     // when
-    when(instance.findOne).calledWith({ id: USER_ID }).mockResolvedValue(user);
-    const resultUser = await instance.findById(USER_ID);
+    await instance.findById(USER_ID);
 
     // then
-    expect(resultUser).toBe(user);
+    expect(instance.findOne).toBeCalledWith({ id: USER_ID });
+    expect(instance.findOne).toBeCalledTimes(1);
   });
 
   it("findByUsername", async () => {
@@ -34,16 +35,15 @@ describe("UserRepository", () => {
     const user = new User();
     user.id = 1;
     user.username = USER_USERNAME;
+
     instance.findOne = jest.fn();
-    when(instance.findOne)
-      .calledWith({ username: USER_USERNAME })
-      .mockResolvedValue(user);
 
     // when
-    const resultUser = await instance.findByUsername(USER_USERNAME);
+    await instance.findByUsername(USER_USERNAME);
 
     // then
-    expect(resultUser).toBe(user);
+    expect(instance.findOne).toBeCalledWith({ username: USER_USERNAME });
+    expect(instance.findOne).toBeCalledTimes(1);
   });
 
   it("addNew", async () => {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -727,6 +727,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz"
   integrity sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==
 
+"@types/node@^14.11.2":
+  version "14.18.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.0.tgz#98df2397f6936bfbff4f089e40e06fa5dd88d32a"
+  integrity sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==
+
 "@types/prettier@^2.1.5":
   version "2.4.2"
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz"
@@ -4204,11 +4209,6 @@ typeorm-transactional-tests@^1.1.5:
   version "1.1.5"
   resolved "https://registry.npmjs.org/typeorm-transactional-tests/-/typeorm-transactional-tests-1.1.5.tgz"
   integrity sha512-/tX9K3ewNGkAL7WcuwWeAJ20nZ0H//IzAhr5jHKu3FJnqJ2DDfi6Cxyd9wooO6IvuxaA06gbp+p+wLpOvpcElg==
-
-typeorm-typedi-extensions@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/typeorm-typedi-extensions/-/typeorm-typedi-extensions-0.4.1.tgz"
-  integrity sha512-05hWktQ4zuXzTTUO3ao56yOezlvUuZhH2NRS//m0SOGCAJoVlfPTMHcmDaMSQy/lMfAwPWoIyn+sfK7ONzTdXQ==
 
 typeorm@^0.2.38:
   version "0.2.41"


### PR DESCRIPTION
- 더이상 사용하지 않는 typedi-typeorm-extensions 삭제
- 모든 Repository interface에서 좀더 낮은 결합도를 위해 Typeorm 의존성 제거
- UserRepo, TagRepo 단위 테스트 작성